### PR TITLE
Show error when da url is not valid. Close #43. Close #48.

### DIFF
--- a/docassemble/ALAutomatedTestingTests/al_set_up_testing.py
+++ b/docassemble/ALAutomatedTestingTests/al_set_up_testing.py
@@ -14,6 +14,7 @@ from docassemble.base.core import DAObject
 
 class TestInstaller(DAObject):
   def init( self, *pargs, **kwargs ):
+    self.errors = []
     super().init(*pargs, **kwargs)
   
   def set_da_info( self ):
@@ -21,16 +22,19 @@ class TestInstaller(DAObject):
     # Can we get granular with error messages?
     log( 1, 'console' )
     server_match = re.match( r"^(http.+)\/interview\?i=docassemble\.playground(\d+).*$", self.playground_url )
-    if server_match is None:
-      log( 2, 'console' )
-      self.server_url = None
-      self.playground_id = None
-      # TODO: Show error
-    else:
-      log( 3, 'console' )
+    if server_match:
       # TODO: More fine-grained validation of this information
       self.server_url = server_match.group(1)
       self.playground_id = server_match.group(2)
+      log( 2, 'console' )
+    else:
+      log( 3, 'console' )
+      self.server_url = None
+      self.playground_id = None
+      # Show error
+      error = ErrorLikeObject( self.da_url_error )
+      self.errors.append( error )
+      log( error, 'console' )
     
     # TODO: Is it possible to try to log into their server to
     # make sure they've given the correct information?
@@ -75,5 +79,8 @@ class TestInstaller(DAObject):
   def update_github( self ):
     return self
   
-  # handle errors
-    
+# handle errors
+class ErrorLikeObject():
+  def __init__( self, message='' ):
+    self.status = 0
+    self.data = { 'message': message }

--- a/docassemble/ALAutomatedTestingTests/data/questions/al_set_up_testing.yml
+++ b/docassemble/ALAutomatedTestingTests/data/questions/al_set_up_testing.yml
@@ -16,17 +16,22 @@ objects:
 # I've done this once before. Trust me...
 mandatory: True
 code: |
+  # For development
+  installer.repo_url = 'https://github.com/plocket/install'
+  #installer.playground_url = 'https://apps-dev.suffolklitlab.org/interview?i=docassemble.playground12ALTestingGitHubAPI%3Aal_set_up_testing.yml#page1'
   
   # handle errors
+  if len( installer.errors ) > 0:
+    show_errors
   
   intro
   
   # da stuff
-  installer.playground_url
+  installer.password
   set_da_info
   
   # github stuff
-  installer.repo_url
+  installer.token
   set_github_auth
   
   # confirm
@@ -81,7 +86,9 @@ fields:
     datatype: email
   - Testing account's password: installer.password
     datatype: password
-  - note: "From inside the testing account, hit 'Save and Run' in the YAML file you want to test. What is the URL in the address bar?"
+  - note: |
+      From inside the testing account, hit 'Save and Run' in the YAML file you want to test. What is the URL in the address bar? Example of a valid URL:[BR]
+      `https://dev.court-wizards.org/interview?i=docassemble.playground222ProjectName%3Asome_file.yml#page2`"
   - Interview URL: installer.playground_url
 terms:
   Interview URL: |
@@ -160,4 +167,24 @@ comment: |
   If everything passes, all should be well and you should be ready to write your first tests. Delete the [personal access token](https://github.com/settings/tokens) you created.
   
   If you are still having trouble or have some feedback, we would love you to [make an issue in our testing package's repository](https://github.com/plocket/docassemble-cucumber/issues).
+---
+id: show_errors
+event: show_errors
+question: |
+  Sorry, something went wrong
+subquestion: |
+  % for error in installer.errors:
+  **Error:** ${ error.data[ 'message' ] }
+  
+  % endfor
+---
+code: |
+  installer.da_url_error = da_url_error.content
+---
+template: da_url_error
+content: |
+  Cannot validate the interview URL **"${ installer.playground_url }"**. Example of a valid URL:[BR]
+  `https://dev.court-wizards.org/interview?i=docassemble.playground222ProjectName%3Asome_file.yml#page2` [BR]
+  If you are sure you have the whole URL of a running interview, please report a bug and include your interview URL in the report.
+---
 ---


### PR DESCRIPTION
Close #43, close #48 - small clarity fixes

Test:
- [ ] On da page, answer with invalid url.
- [ ] Next page is error screen with explanation.