### PR TITLE
#37 Add currently desired errors

### DIFF
--- a/docassemble/ALAutomatedTestingTests/al_set_up_testing.py
+++ b/docassemble/ALAutomatedTestingTests/al_set_up_testing.py
@@ -78,16 +78,16 @@ class TestInstaller(DAObject):
       branch_data = self.get_free_branch_name()
       self.branch_name = branch_data[ 'branch_name' ]
       if not branch_data[ 'found_free_name' ]:
-        error = ErrorLikeObject( message='Branch already exists', details=self.github_branch_name_error )
-        self.errors.append( error )
-        log( error.__dict__, 'console' )
+        error3 = ErrorLikeObject( message='Branch already exists', details=self.github_branch_name_error )
+        self.errors.append( error3 )
+        log( error3.__dict__, 'console' )
         
       # Check user has access to the repo (403)
       has_access = self.repo.has_in_collaborators( self.user_name )
       if not has_access:
-        error3 = ErrorLikeObject( message='Must have push access', details=self.github_access_error )
-        self.errors.append( error3 )
-        log( error3.__dict__, 'console' )
+        error4 = ErrorLikeObject( message='Must have push access', details=self.github_access_error )
+        self.errors.append( error4 )
+        log( error4.__dict__, 'console' )
     
     # Give as many errors at once as is possible
     if len( self.errors ) > 0:
@@ -179,7 +179,7 @@ class TestInstaller(DAObject):
     return self
   
   def make_new_branch( self ):
-    """Create new branch off the default branch. PyGithub .create_git_ref()"""
+    """Create new branch off the default branch."""
     # Get default branch
     repo = self.repo
     default_branch_name = repo.default_branch

--- a/docassemble/ALAutomatedTestingTests/al_set_up_testing.py
+++ b/docassemble/ALAutomatedTestingTests/al_set_up_testing.py
@@ -13,6 +13,7 @@ from docassemble.base.core import DAObject
 # Mostly: https://pygithub.readthedocs.io/en/latest/introduction.html
 
 class TestInstaller(DAObject):
+  # In da `init` is the initializing function, NOT python's __init__
   def init( self, *pargs, **kwargs ):
     self.default_branch_name = "automated_testing"
     self.errors = []  # Make set() instead?

--- a/docassemble/ALAutomatedTestingTests/data/questions/al_set_up_testing.yml
+++ b/docassemble/ALAutomatedTestingTests/data/questions/al_set_up_testing.yml
@@ -19,9 +19,9 @@ include:
 # I've done this once before. Trust me...
 mandatory: True
 code: |
-  ## for dev
-  #installer.repo_url = 'https://github.com/CaroRob/docassemble-DeadBrokeDads2'
-  #installer.playground_url = 'https://apps-dev.suffolklitlab.org/interview?i=docassemble.playground12ALTestingGHSendFiles%3Aal_set_up_testing.yml#page4'
+  # for dev
+  #installer.repo_url = 'https://github.com/plocket/install'
+  installer.playground_url = 'https://apps-dev.suffolklitlab.org/interview?i=docassemble.playground12ALTestingGHSendFiles%3Aal_set_up_testing.yml#page4'
   
   # show errors first thing on each loop
   if len( installer.errors ) > 0:
@@ -191,8 +191,8 @@ question: |
   Sorry, something went wrong
 subquestion: |
   % for error in installer.errors:
-  **Error:** ${ error.status if error.status else '' } ${ error.data[ 'message' ] if error.data[ 'message' ] else '' }
-  ${ '[BR]' + error.data[ 'details' ] if error.data[ 'details' ] else '' }
+  **Error: ${ error.status if error.status else '' } ${ error.data[ 'message' ] }**
+  ${ '[BR]' + error.data[ 'details' ] }
   <hr/>
   
   % endfor
@@ -204,7 +204,7 @@ code: |
 template: da_url_error
 content: |
   Cannot validate the interview URL **"${ installer.playground_url }"**. Example of a valid URL:[BR]
-  `https://dev.court-wizards.org/interview?i=docassemble.playground222ProjectName%3Asome_file.yml#page2` [BR]
+  `https://dev.court-wizards.org/interview?i=docassemble.playground222ProjectName%3Asome_file.yml` [BR]
   If you are sure you have the whole URL of a running interview, please file an issue and include your interview URL in the report.
 ---
 depends on: github_url_error
@@ -233,9 +233,25 @@ code: |
 ---
 template: github_repo_not_found_error
 content: |
-  GitHub cannot find **${ 'the ' + installer.repo_name if installer.repo_name else 'that' }** repository owned by **${ installer.owner_name if installer.owner_name else 'that user' }**. Example of a valid URL:
+  GitHub cannot find the **${ installer.repo_name }** repository owned by the owner **${ installer.owner_name }**. Example of a valid URL:
   
   `https://github.com/owner_name/repo_name`
   
-  You gave the repository address of **${ installer.repo_url }**. Are you sure that's correct?
+  You gave the repository address of **${ installer.repo_url }**. Are you sure that is correct?
+---
+depends on: github_access_error
+code: |
+  installer.github_access_error = github_access_error.content
+---
+template: github_access_error
+content: |
+  The user **${ installer.user_name }** does not have access to change the files in the **${ installer.repo_name }** repository owned by the owner **${ installer.owner_name }**. You can ask the admin to give correct access.
+---
+depends on: github_branch_name_error
+code: |
+  installer.github_branch_name_error = github_branch_name_error.content
+---
+template: github_branch_name_error
+content: |
+  It looks like all the allowed branch names are taken. To solve this, delete some of the branches that start with "${ installer.default_branch_name }".
 ---

--- a/docassemble/ALAutomatedTestingTests/data/questions/al_set_up_testing.yml
+++ b/docassemble/ALAutomatedTestingTests/data/questions/al_set_up_testing.yml
@@ -20,10 +20,10 @@ include:
 mandatory: True
 code: |
   ## for dev
-  #installer.repo_url = 'https://github.com/plocket/install'
+  #installer.repo_url = 'https://github.com/CaroRob/docassemble-DeadBrokeDads2'
   #installer.playground_url = 'https://apps-dev.suffolklitlab.org/interview?i=docassemble.playground12ALTestingGHSendFiles%3Aal_set_up_testing.yml#page4'
   
-  # handle errors
+  # show errors first thing on each loop
   if len( installer.errors ) > 0:
     show_errors
   
@@ -105,7 +105,7 @@ fields:
     datatype: password
   - note: |
       From inside the testing account, hit 'Save and Run' in the YAML file you want to test. What is the URL in the address bar? Example of a valid URL:[BR]
-      `https://dev.court-wizards.org/interview?i=docassemble.playground222ProjectName%3Asome_file.yml#page2`"
+      `https://dev.court-wizards.org/interview?i=docassemble.playground222ProjectName%3Asome_file.yml#page2`
   - Interview URL: installer.playground_url
 terms:
   Interview URL: |
@@ -144,7 +144,7 @@ review:
       
       **Playground ID**: ${ installer.playground_id }
       
-      **URL of running testable interview**:[BR]
+      **URL for running testable interview**:[BR]
       [${ installer.playground_url }](${ installer.playground_url })
   - Edit: installer.repo_url
     button: |
@@ -191,10 +191,13 @@ question: |
   Sorry, something went wrong
 subquestion: |
   % for error in installer.errors:
-  **Error:** ${ error.data[ 'message' ] }
+  **Error:** ${ error.status if error.status else '' } ${ error.data[ 'message' ] if error.data[ 'message' ] else '' }
+  ${ '[BR]' + error.data[ 'details' ] if error.data[ 'details' ] else '' }
+  <hr/>
   
   % endfor
 ---
+depends on: da_url_error
 code: |
   installer.da_url_error = da_url_error.content
 ---
@@ -202,6 +205,37 @@ template: da_url_error
 content: |
   Cannot validate the interview URL **"${ installer.playground_url }"**. Example of a valid URL:[BR]
   `https://dev.court-wizards.org/interview?i=docassemble.playground222ProjectName%3Asome_file.yml#page2` [BR]
-  If you are sure you have the whole URL of a running interview, please report a bug and include your interview URL in the report.
+  If you are sure you have the whole URL of a running interview, please file an issue and include your interview URL in the report.
 ---
+depends on: github_url_error
+code: |
+  installer.github_url_error = github_url_error.content
+---
+template: github_url_error
+content: |
+  Cannot validate the GitHub URL **"${ installer.repo_url }"**. Example of a valid URL:
+  
+  `https://github.com/owner_name/repo_name`
+  
+  If you are sure you have the correct GitHub URL, please file an issue and include the GitHub URL.
+---
+depends on: github_token_error
+code: |
+  installer.github_token_error = github_token_error.content
+---
+template: github_token_error
+content: |
+  GitHub does not recognize [that personal access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token). You can try copying and pasting it again or you can try making a new one.
+---
+depends on: github_repo_not_found_error
+code: |
+  installer.github_repo_not_found_error = github_repo_not_found_error.content
+---
+template: github_repo_not_found_error
+content: |
+  GitHub cannot find **${ 'the ' + installer.repo_name if installer.repo_name else 'that' }** repository owned by **${ installer.owner_name if installer.owner_name else 'that user' }**. Example of a valid URL:
+  
+  `https://github.com/owner_name/repo_name`
+  
+  You gave the repository address of **${ installer.repo_url }**. Are you sure that's correct?
 ---

--- a/docassemble/ALAutomatedTestingTests/data/questions/al_set_up_testing.yml
+++ b/docassemble/ALAutomatedTestingTests/data/questions/al_set_up_testing.yml
@@ -19,9 +19,9 @@ include:
 # I've done this once before. Trust me...
 mandatory: True
 code: |
-  # for dev
+  ## for dev
   #installer.repo_url = 'https://github.com/plocket/install'
-  installer.playground_url = 'https://apps-dev.suffolklitlab.org/interview?i=docassemble.playground12ALTestingGHSendFiles%3Aal_set_up_testing.yml#page4'
+  #installer.playground_url = 'https://apps-dev.suffolklitlab.org/interview?i=docassemble.playground12ALTestingGHSendFiles%3Aal_set_up_testing.yml#page4'
   
   # show errors first thing on each loop
   if len( installer.errors ) > 0:


### PR DESCRIPTION
Addresses #37. Also fixes #69, using user as owner instead of getting actual owner in github url. Needed to fix that to get the proper error messages working.

A bit annoying to check all the permutations as I tried to show as many errors as possible instead of one at a time, so there's combinations to take into account.

- Changed `ErrorLikeObject` a bit to allow more organized and consistent error message creation.
- Moved all github error handling into `.set_github_auth()`. It basically tries to find everything that could possibly be wrong with the github data so that the user will get the info before they trigger the actual process. That's to avoid giving them a sense that they're about to succeed before it gets snatched away.
- To help with error message accumulation:
   - Changed the consequences of non-matching regex to create empty strings instead of `None` so that more error info could be accumulated more easily.
   - Checked for branch name availability in `.set_github_auth()` explicitly instead of triggering an error later on.
   - Got a bit more permissive with matching github urls because of my own experience copy/pasting.

After this, I think we just need to actually incorporate the 'next steps' instructions at the end.