### PR TITLE
Fix #44, add `requests` to dependencies. I think that's all, but I ca…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(name='docassemble.ALAutomatedTestingTests',
       url='https://docassemble.org',
       packages=find_packages(),
       namespace_packages=['docassemble'],
-      install_requires=['PyGithub>=1.54.1', 'PyNaCl>=1.4.0'],
+      install_requires=['PyGithub>=1.54.1', 'PyNaCl>=1.4.0', 'requests>=2.25.0'],
       zip_safe=False,
       package_data=find_package_data(where='docassemble/ALAutomatedTestingTests/', package='docassemble.ALAutomatedTestingTests'),
      )


### PR DESCRIPTION
Fix #44. Would love a second opinion on this and an explanation of how one can know the names of python packages.

…n't be sure as apparently python packages can import from a different name than they seem to have. For example, PyGithub is stated in the import as Github.