### PR TITLE
Bring back show if checkboxes. Close #92.

### DIFF
--- a/docassemble/ALAutomatedTestingTests/data/questions/all_tests.yml
+++ b/docassemble/ALAutomatedTestingTests/data/questions/all_tests.yml
@@ -81,14 +81,17 @@ subquestion: |
 fields:
   - checkboxes (yesno): checkboxes_yesno
     datatype: yesno
+  # TODO: Add checkbox yesno to leave blank
   - checkboxes (other): checkboxes_other
     datatype: checkboxes
     choices: 
        - checkboxes opt 1: checkbox_other_opt_1
        - checkboxes opt 2: checkbox_other_opt_2
        - checkboxes opt 3: checkbox_other_opt_3
+  # TODO: Add checkbox (other) to test 'none of the above'
   - radio (yesno): radio_yesno
     datatype: yesnoradio
+  # TODO: Add radio yesno to choose 'no'
   - radio (other): radio_other
     datatype: radio
     choices: 
@@ -125,20 +128,23 @@ fields:
   - Show layer 3: show_3
     datatype: yesno
     show if: show_2
+  # TODO: Add checkbox yesno to leave blank
   - showif checkbox yesno: showif_checkbox_yesno
     datatype: yesno
     show if: show_3
-  # Reimplement when refactoring for #158 (in dc) is done
   # A checkbox's none of the above `for` value is unique
-  #- showif checkboxes (multiple): showif_checkboxes_other
-  #  datatype: checkboxes
-  #  choices:
-  #    - showif checkbox nota 1: showif_checkboxes_nota_1
-  #    - showif checkbox nota 2: showif_checkboxes_nota_2
-  #  show if: show_3
+  - showif checkboxes (multiple): showif_checkboxes_other
+    datatype: checkboxes
+    choices:
+      - showif checkbox nota 1: showif_checkboxes_nota_1
+      - showif checkbox nota 2: showif_checkboxes_nota_2
+      - showif checkbox nota 3: showif_checkboxes_nota_3
+    show if: show_3
+  # TODO: Add checkbox (other) to test 'none of the above'
   - showif yesnoradio: showif_yesnoradio 
     datatype: yesnoradio
     show if: show_3
+  # TODO: Add radio yesno to choose 'no'
   - showif radio (multiple): showif_radio_other
     datatype: radio
     choices:


### PR DESCRIPTION
Closes #92. These were removed to allow development and passing of other tests. Need to be re-implemented now.

[Tested locally and cucumber is passing, so that's good.]