### PR TITLE
Close #102, save testing files in da 'sources' folder

### DIFF
--- a/docassemble/ALAutomatedTestingTests/al_set_up_testing.py
+++ b/docassemble/ALAutomatedTestingTests/al_set_up_testing.py
@@ -197,7 +197,8 @@ class TestInstaller(DAObject):
     https://pygithub.readthedocs.io/en/latest/examples/Repository.html#create-a-new-file-in-the-repository'''
     # https://pygithub.readthedocs.io/en/latest/github_objects/Repository.html#github.Repository.Repository.create_file"""
     test_path = 'docassemble/' + self.package_name + '/data/sources/example_test.feature'
-    self.send_file( test_path, 'Add tests/features/example_test.feature', self.example_test_str )  # 2
+    test_commit_message = 'Add ' + test_path
+    self.send_file( test_path, test_commit_message, self.example_test_str )  # 2
     self.send_file( '.env_example', 'Add .env_example', self.env_example_str )  # 1
     self.send_file( '.gitignore', 'Add .gitignore', self.gitignore_str )  # 3
     self.send_file( 'package.json', 'Add package.json', self.package_json_str )  # 4

--- a/docassemble/ALAutomatedTestingTests/al_set_up_testing.py
+++ b/docassemble/ALAutomatedTestingTests/al_set_up_testing.py
@@ -113,6 +113,7 @@ class TestInstaller(DAObject):
     if matches:
       self.owner_name = matches.group(1)
       self.repo_name = matches.group(2)
+      self.package_name = re.sub( r'docassemble-', '', self.repo_name )
     else:
       self.owner_name = ''
       self.repo_name = ''
@@ -195,11 +196,12 @@ class TestInstaller(DAObject):
     """Send files to folders in new branch in github.
     https://pygithub.readthedocs.io/en/latest/examples/Repository.html#create-a-new-file-in-the-repository'''
     # https://pygithub.readthedocs.io/en/latest/github_objects/Repository.html#github.Repository.Repository.create_file"""
+    test_path = 'docassemble/' + self.package_name + '/data/sources/example_test.feature'
+    self.send_file( test_path, 'Add tests/features/example_test.feature', self.example_test_str )  # 2
     self.send_file( '.env_example', 'Add .env_example', self.env_example_str )  # 1
-    self.send_file( 'tests/features/example_test.feature', 'Add tests/features/example_test.feature', self.example_test_str )  # 2
     self.send_file( '.gitignore', 'Add .gitignore', self.gitignore_str )  # 3
     self.send_file( 'package.json', 'Add package.json', self.package_json_str )  # 4
-    self.send_file( '.github/workflows/run_form_tests.yml', 'Add r.github/workflows/run_form_tests.yml', self.run_form_tests_str )  # 5
+    self.send_file( '.github/workflows/run_form_tests.yml', 'Add github/workflows/run_form_tests.yml', self.run_form_tests_str )  # 5
     return self
   
   def send_file( self, path, msg, contents ):

--- a/docassemble/ALAutomatedTestingTests/data/questions/al_set_up_testing.yml
+++ b/docassemble/ALAutomatedTestingTests/data/questions/al_set_up_testing.yml
@@ -136,42 +136,6 @@ fields:
     datatype: password
     help: "As long as you have permission to change the repository's files, your personal access token will give us permission to change them too."
 ---
-# By default, da will now allow editing of .feature files
-# https://github.com/jhpyle/docassemble/pull/394
-
-#id: files location
-#question: |
-#  Files
-#subquestion: |
-#  You can keep your test files in two places. This will affect how and where developers can edit them. We recommend picking just one location to keep things consistent.
-#  
-#  Where would you like to keep your test files?
-#fields:
-#  - The docassemble Sources folder: sources_folder
-#    datatype: yesno
-#  - note: |
-#      **Pros:**
-#      
-#      - Developers are often more familiar with editing code in the Playground.
-#      - Since tests will be updated at the same time as interview code, the developer has a chance to avoid working interviews failing just because the tests don't yet line up with the new code.
-#      - Developers can also edit the tests on their local machine.
-#      
-#      **Cons:**
-#      
-#      - The admin of your server must [set a server-wide configuration to allow `.feature` files to be edited](https://docassemble.org/docs/config.html#editable%20extensions).
-#  - The `tests/features` folder: tests_folder
-#    datatype: yesno
-#  - note: |
-#      **Pros:**
-#      
-#      - To set this up, you only have to finish this interview.
-#      - Developers can also edit the tests on their local machine.
-#      - Developers will still be able to edit the tests on your local machine.
-#      
-#      **Cons:**
-#      
-#      - Developers will not be able to edit the tests in the Playground.
----
 id: confirm info
 question: |
   Are you ready?

--- a/docassemble/ALAutomatedTestingTests/data/questions/al_set_up_testing.yml
+++ b/docassemble/ALAutomatedTestingTests/data/questions/al_set_up_testing.yml
@@ -49,6 +49,10 @@ code: |
   next_steps
 ---
 code: |
+  installer.set_da_info()
+  set_da_info = True
+---
+code: |
   installer.set_github_auth()
   set_github_auth = True
 ---
@@ -76,12 +80,12 @@ subquestion: |
   
   Your answers will be encrypted end-to-end and on the server. No one other than you will have access to it. You **must** make sure your GitHub account has permission to change files in the correct repository.
 
-  :clock: This could take about 15 minutes
+  :clock: This could take about 20 minutes
   
   We will need you to give us:
   
   1. A [GitHub personal access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) with 'repo' and 'workflow' level permissions.
-  1. Your docassemble testing account's sign-in information. That can be your account if you want it to be.
+  1. Your docassemble testing account's sign-in information. You can use your own account if you want.
 
   This tool will add some files to different folders in your interview's GitHub repository:
 
@@ -103,7 +107,7 @@ id: server info
 question: |
   Docassemble
 subquestion: |
-  Use the information for the account that should run the tests to answer the questions below. You can use your own account as the testing account.
+  Answer the questions below using the information for the docassemble account that should run the tests. You can use your own account as the testing account.
 fields:
   - Testing account's email: installer.email
     datatype: email
@@ -117,11 +121,6 @@ terms:
   Interview URL: |
     The interview URL will give us the account's Playground ID and the address of the server that the account is on.
 ---
-# da info
-code: |
-  installer.set_da_info()
-  set_da_info = True
----
 # TODO: Add instructions on how to find the GitHub repo url on Packages page (maybe point to docs)
 id: github auth
 question: |
@@ -129,13 +128,49 @@ question: |
 subquestion: |
   In order to change files in your GitHub repository, we need permission. If you have permission to change the files of the repository, you can give us permission too.
   
-  To do that, create a [personal access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) that has 'repo' and 'workflow' level permissions. You can delete the token any time after confirming the setup has worked. You can also use a new one anytime.
+  To do that, create a [personal access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) that has 'repo' and 'workflow' level permissions. You can delete the token later.
 fields:
   - GitHub repository URL: installer.repo_url
     help: "The repository's URL will give us the name of the repo and its owner."
   - Personal access token: installer.token
     datatype: password
     help: "As long as you have permission to change the repository's files, your personal access token will give us permission to change them too."
+---
+# By default, da will now allow editing of .feature files
+# https://github.com/jhpyle/docassemble/pull/394
+
+#id: files location
+#question: |
+#  Files
+#subquestion: |
+#  You can keep your test files in two places. This will affect how and where developers can edit them. We recommend picking just one location to keep things consistent.
+#  
+#  Where would you like to keep your test files?
+#fields:
+#  - The docassemble Sources folder: sources_folder
+#    datatype: yesno
+#  - note: |
+#      **Pros:**
+#      
+#      - Developers are often more familiar with editing code in the Playground.
+#      - Since tests will be updated at the same time as interview code, the developer has a chance to avoid working interviews failing just because the tests don't yet line up with the new code.
+#      - Developers can also edit the tests on their local machine.
+#      
+#      **Cons:**
+#      
+#      - The admin of your server must [set a server-wide configuration to allow `.feature` files to be edited](https://docassemble.org/docs/config.html#editable%20extensions).
+#  - The `tests/features` folder: tests_folder
+#    datatype: yesno
+#  - note: |
+#      **Pros:**
+#      
+#      - To set this up, you only have to finish this interview.
+#      - Developers can also edit the tests on their local machine.
+#      - Developers will still be able to edit the tests on your local machine.
+#      
+#      **Cons:**
+#      
+#      - Developers will not be able to edit the tests in the Playground.
 ---
 id: confirm info
 question: |
@@ -158,6 +193,12 @@ review:
       **Your username**:[BR]
       ${ installer.user_name }
       
+      **Package name with correct capitalization**:[BR]
+      ${ installer.package_name }
+      
+      **Path to testing files in GitHub**:[BR]
+      `${ 'docassemble/' + installer.package_name + '/data/sources' }`
+      
       **Repository URL**:[BR]
       [https://github.com/${ installer.owner_name }/${ installer.repo_name }](https://github.com/${ installer.owner_name }/${ installer.repo_name })
 continue button field: is_ready
@@ -170,24 +211,32 @@ event: next_steps
 question: |
   Next steps
 subquestion: |
+  Follow the instructions below to finish installing your automated integrated testing.
+
   % if defined( 'installer.pull_url' ):
   1. Check [the pull request](${ installer.pull_url }) and merge it in if it looks good.
   1. Once you've merged your pull request into your default branch (usually 'main' or 'master') [go to your actions page](https://github.com/${ installer.owner_name }/${ installer.repo_name }/actions) to see the first example test being run.
   % else:
   1. [Go to your actions page](https://github.com/${ installer.owner_name }/${ installer.repo_name }/actions) to see the example test being run.
   % endif
-  1. If it fails the first time, [rerun the test (job)](https://docs.github.com/en/actions/managing-workflow-runs/re-running-a-workflow).
-  1. If it fails again:
-      1. Check the .github/workflows/run_interview_tests.yml `env:` section to make sure your docassemble server name is right.
-      1. If it is wrong, you can [edit the file in GitHub](https://docs.github.com/en/github/managing-files-in-a-repository/editing-files-in-your-repository).
-      1. [Edit the values](https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository) of [the repository secrets](https://github.com/${ installer.owner_name }/${ installer.repo_name }/secrets) manually to make sure that the email address, password, and id are for the correct account on the correct server. GitHub will not let you see the old values as that would be a breach of security.
-      1. [Run the test manually](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow#running-a-workflow-on-github).
-      1. If tests still fail, [see if someone has posted a related issue](https://github.com/plocket/docassemble-ALAutomatedTestingTests/issues) in our repository. If not, [file a new issue](https://github.com/plocket/docassemble-ALAutomatedTestingTests/issues/new) that includes the link to the manual test that was run. Leave that test alone so others can see what's going on. Avoid 'rerunning' that job.
-  1. When that test run is over, see if you can [run the workflow manually from the actions menu](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow#running-a-workflow-on-github).
+  
+  If the test fails the first time, [rerun the test (job)](https://docs.github.com/en/actions/managing-workflow-runs/re-running-a-workflow). If it fails again:
+  
+  1. Check the .github/workflows/run_interview_tests.yml `env:` section to make sure your docassemble server name is right.
+  1. If it is wrong, you can [edit the file in GitHub](https://docs.github.com/en/github/managing-files-in-a-repository/editing-files-in-your-repository).
+  1. [Edit the values](https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository) of [the repository secrets](https://github.com/${ installer.owner_name }/${ installer.repo_name }/secrets) manually. The fields will be blank - GitHub will not let you see the old values as that would be a breach of security. Make sure that the email address, password, and id are for the correct account on the correct server. 
+  1. [Run the test manually](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow#running-a-workflow-on-github).
+  1. If tests still fail, [see if someone has posted a related issue](https://github.com/plocket/docassemble-ALAutomatedTestingTests/issues) in our repository. If not, [file a new issue](https://github.com/plocket/docassemble-ALAutomatedTestingTests/issues/new) that includes the link to the manual test that was run. Leave that test alone so others can see what's going on. Avoid 'rerunning' that job.
+  
+  When that first test run is over, see if you can [run the workflow manually from the actions menu](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow#running-a-workflow-on-github).
 
-  If everything passes, all should be well and you should be ready to write your first tests. Delete the [personal access token](https://github.com/settings/tokens) you created.
+  If everything passes, all should be well and you should be ready to create your first tests in your docassemble Sources folder.
+  
+  Delete the [personal access token](https://github.com/settings/tokens) you created.
   
   If you have some feedback, we would love to hear from you. [Make an issue in our repository](https://github.com/plocket/docassemble-ALAutomatedTestingTests/issues/new) to tell us about it.
+buttons:
+  - Restart: restart
 comment: |
   TODO: Should we offer to delete their personal access token for them in the interview itself? Do we have enough permissions?
   TODO: Implement feedback form instead of linking issues. See AL core for that coming soon.

--- a/docassemble/ALAutomatedTestingTests/data/questions/al_testing_files_to_push.yml
+++ b/docassemble/ALAutomatedTestingTests/data/questions/al_testing_files_to_push.yml
@@ -35,10 +35,9 @@ content: |
   @example_feature_tag
   Feature: An example test
 
-  The tests in this file should cover
-  - [x] Provide a template people can use to make their own tests.
-  - [ ] Direct people to more documentation.
-  - [ ] Find the ultimate question to life, the universe, and everything.
+  What specific behavior this file should test
+  [x] Make sure the Project runs on the server
+  [ ] Make sure the interview itself starts
 
   @example_scenario_tag
   Scenario: Server finishes reloading
@@ -70,9 +69,9 @@ content: |
     "scripts": {
       "test": "npm run langs_setup && npm run cucumber -- $@",
       "cucumber_base": "./node_modules/.bin/cucumber-js --require ./node_modules/docassemble-cucumber/lib/index.js",
-      "cucumber": "run_cucumber(){ npm run cucumber_base -- \"$@\" tests/features/*.feature docassemble/*/data/sources/*.feature; }; run_cucumber",
-      "langs": "npm run langs_setup && ./node_modules/.bin/cucumber-js --require ./node_modules/docassemble-cucumber/lib/index.js tests/features/*_lang*.feature",
-      "langs_setup": "node_modules/.bin/da-langs 'tests/features/*.feature'",
+      "cucumber": "run_cucumber(){ npm run cucumber_base -- \"$@\" docassemble/*/data/sources/*.feature; }; run_cucumber",
+      "langs": "npm run langs_setup && ./node_modules/.bin/cucumber-js --require ./node_modules/docassemble-cucumber/lib/index.js docassemble/*/data/sources/*_lang*.feature",
+      "langs_setup": "node_modules/.bin/da-langs 'docassemble/*/data/sources/*.feature'",
       "langs_local": "npm run langs_setup && npm run local",
       "local": "npm run setup && npm run cucumber; npm run takedown",
       "setup": "node_modules/.bin/da-setup",

--- a/docassemble/ALAutomatedTestingTests/data/questions/al_testing_files_to_push.yml
+++ b/docassemble/ALAutomatedTestingTests/data/questions/al_testing_files_to_push.yml
@@ -70,7 +70,7 @@ content: |
     "scripts": {
       "test": "npm run langs_setup && npm run cucumber -- $@",
       "cucumber_base": "./node_modules/.bin/cucumber-js --require ./node_modules/docassemble-cucumber/lib/index.js",
-      "cucumber": "run_cucumber(){ npm run cucumber_base -- \"$@\" tests/features/*.feature docassemble/*/data/sources/*.feature; }; run_cucumber",
+      "cucumber": "run_cucumber(){ npm run cucumber_base -- \"$@\" tests/features/*.feature docassemble/*/data/sources/*.feature }; run_cucumber",
       "langs": "npm run langs_setup && ./node_modules/.bin/cucumber-js --require ./node_modules/docassemble-cucumber/lib/index.js tests/features/*_lang*.feature",
       "langs_setup": "node_modules/.bin/da-langs 'tests/features/*.feature'",
       "langs_local": "npm run langs_setup && npm run local",

--- a/docassemble/ALAutomatedTestingTests/data/questions/al_testing_files_to_push.yml
+++ b/docassemble/ALAutomatedTestingTests/data/questions/al_testing_files_to_push.yml
@@ -70,7 +70,7 @@ content: |
     "scripts": {
       "test": "npm run langs_setup && npm run cucumber -- $@",
       "cucumber_base": "./node_modules/.bin/cucumber-js --require ./node_modules/docassemble-cucumber/lib/index.js",
-      "cucumber": "run_cucumber(){ npm run cucumber_base -- \"$@\" tests/features/*.feature; }; run_cucumber",
+      "cucumber": "run_cucumber(){ npm run cucumber_base -- \"$@\" tests/features/*.feature docassemble/*/data/sources/*.feature; }; run_cucumber",
       "langs": "npm run langs_setup && ./node_modules/.bin/cucumber-js --require ./node_modules/docassemble-cucumber/lib/index.js tests/features/*_lang*.feature",
       "langs_setup": "node_modules/.bin/da-langs 'tests/features/*.feature'",
       "langs_local": "npm run langs_setup && npm run local",

--- a/docassemble/ALAutomatedTestingTests/data/questions/al_testing_files_to_push.yml
+++ b/docassemble/ALAutomatedTestingTests/data/questions/al_testing_files_to_push.yml
@@ -38,6 +38,7 @@ content: |
   What specific behavior this file should test
   [x] Make sure the Project runs on the server
   [ ] Make sure the interview itself starts
+  [ ] Find the ultimate question to life, the universe, and everything.
 
   @example_scenario_tag
   Scenario: Server finishes reloading

--- a/docassemble/ALAutomatedTestingTests/data/questions/al_testing_files_to_push.yml
+++ b/docassemble/ALAutomatedTestingTests/data/questions/al_testing_files_to_push.yml
@@ -70,7 +70,7 @@ content: |
     "scripts": {
       "test": "npm run langs_setup && npm run cucumber -- $@",
       "cucumber_base": "./node_modules/.bin/cucumber-js --require ./node_modules/docassemble-cucumber/lib/index.js",
-      "cucumber": "run_cucumber(){ npm run cucumber_base -- \"$@\" tests/features/*.feature docassemble/*/data/sources/*.feature }; run_cucumber",
+      "cucumber": "run_cucumber(){ npm run cucumber_base -- \"$@\" tests/features/*.feature docassemble/*/data/sources/*.feature; }; run_cucumber",
       "langs": "npm run langs_setup && ./node_modules/.bin/cucumber-js --require ./node_modules/docassemble-cucumber/lib/index.js tests/features/*_lang*.feature",
       "langs_setup": "node_modules/.bin/da-langs 'tests/features/*.feature'",
       "langs_local": "npm run langs_setup && npm run local",


### PR DESCRIPTION
Closes #102. Lets developers update tests at the same time as updating their interviews. See passing action and check folder locations: https://github.com/plocket/docassemble-ALAutomatedTestingTests/actions/runs/741358145

Comes after https://github.com/plocket/docassemble-cucumber/pull/213

Also tweaks some other wording and presentation.