### PR TITLE
Ignore file containing the docassemble project name. Not urgent, just…

### DIFF
--- a/docassemble/ALAutomatedTestingTests/data/questions/al_testing_files_to_push.yml
+++ b/docassemble/ALAutomatedTestingTests/data/questions/al_testing_files_to_push.yml
@@ -56,6 +56,7 @@ content: |
   downloads_*
   *_lang_*.feature
   *_report_*
+  _al_test_project_name*
 ---
 template: installer.package_json
 content: |


### PR DESCRIPTION
… convenient for local devs.