### PR TITLE
Close #140, add ability to set org secrets

### DIFF
--- a/docassemble/ALAutomatedTestingTests/al_set_up_testing.py
+++ b/docassemble/ALAutomatedTestingTests/al_set_up_testing.py
@@ -65,22 +65,22 @@ class TestInstaller(DAObject):
       error1.data[ 'details' ] = self.github_token_error
       self.errors.append( error1 )
     
+    # If wants to do any repo stuff. Also defines self.owner_name if it's not defined already.
+    if value( 'wants_to_set_repo_secrets' ) or value( 'wants_to_set_up_tests' ):
+      self.repo = self.get_repo( self.repo_url )
+      if self.repo:
+        is_valid_collaborator = self.is_repo_collaborator()
+        self.is_repo_admin()
+    
     # Set org secrets
     is_valid_org_admin = False
     if ( value( 'wants_to_set_org_secrets' )):
       self.org = self.get_org()
       if self.org and user:
         is_valid_org_admin = self.is_valid_org_admin( user, self.org.login )
-    
-    # If wants to do any repo stuff
-    if value( 'wants_to_set_repo_secrets' ):
-      self.repo = self.get_repo( self.repo_url )
-      if self.repo:
-        self.is_repo_collaborator()  
-        self.is_repo_admin()
         
     #has_valid_min_repo_permissions = False
-    #if value( 'wants_to_set_repo_secrets' ):  # or value( 'wants_to_set_up_tests' ):
+    #if value( 'wants_to_set_repo_secrets' ):  #
     #  if self.validate_repo():
     #    if self.validate_repo_collaborator_auth()  # Minimum permissions required
     #      has_valid_min_repo_permissions = True
@@ -258,11 +258,12 @@ class TestInstaller(DAObject):
   
   def put_secret( self, secret_name, secret_value ):
     """Add or update one secret to the GitHub repo."""
+    # Encryption by hand in case the lib gets discontinued: https://gist.github.com/plocket/af03ac9326b2ae6d36c937b125b2ea0a
     # Create repo secret: https://docs.github.com/en/rest/reference/actions#create-or-update-a-repository-secret
     
     if value('wants_to_set_org_secrets'):
       # No PyGithub secrets for org yet
-      # encryption by hand: https://github.com/PyGithub/PyGithub/blob/master/github/PublicKey.py#L39-L44
+      # by hand: https://github.com/PyGithub/PyGithub/blob/master/github/PublicKey.py#L39-L44
       # https://github.com/PyGithub/PyGithub/blob/master/github/Repository.py#L1420-L1438
       # https://pygithub.readthedocs.io/en/latest/github_objects/PublicKey.html
       headers1, data = self.org._requester.requestJsonAndCheck(

--- a/docassemble/ALAutomatedTestingTests/al_set_up_testing.py
+++ b/docassemble/ALAutomatedTestingTests/al_set_up_testing.py
@@ -69,7 +69,7 @@ class TestInstaller(DAObject):
       self.has_right_scopes( self.github.oauth_scopes )
     
     # If wants to do any repo stuff. Also defines self.owner_name if it's not defined already.
-    if value( 'wants_to_set_repo_secrets' ) or value( 'wants_to_set_up_tests' ):
+    if value( 'secrets_need' ) == 'repo' or value( 'wants_to_set_up_tests' ):
       self.repo = self.get_repo( self.repo_url )
       if self.repo:
         # TODO: Add branch name to confirmation page or final page?
@@ -78,7 +78,7 @@ class TestInstaller(DAObject):
         self.has_correct_permissions()
     
     # Auth for setting org secrets
-    if ( value( 'wants_to_set_org_secrets' )):
+    if ( value('secrets_need') == 'org' ):
       self.org = self.get_org()
       if self.org and user:
         self.is_valid_org_admin( user, self.org.login )
@@ -88,9 +88,9 @@ class TestInstaller(DAObject):
   def has_right_scopes( self, scopes ):
     """Make sure the developer gave the token the right scopes"""
     # TODO: discuss: Really if just setting repo secrets, only need repo permissions, but do we want to make it that complicated/inconsistent?
-    if value('wants_to_set_org_secrets') and value('wants_to_set_up_tests'):
+    if value('secrets_need') == 'org' and value('wants_to_set_up_tests'):
       has_scopes = "admin:org" in scopes and "workflow" in scopes and "repo" in scopes
-    elif value('wants_to_set_org_secrets') and not value('wants_to_set_up_tests'):
+    elif value('secrets_need') == 'org' and not value('wants_to_set_up_tests'):
       has_scopes = "admin:org" in scopes
     else:
       has_scopes = "workflow" in scopes and "repo" in scopes
@@ -241,7 +241,7 @@ class TestInstaller(DAObject):
   ###############################
   def update_github( self ):
     """If desired, set repo or org secrets. If desired, add test files to repo."""
-    if value( 'wants_to_set_org_secrets' ) or value( 'wants_to_set_repo_secrets' ):
+    if value('secrets_need') == 'org' or value('secrets_need') == 'repo':
       self.create_secrets()
     if value( 'wants_to_set_up_tests' ):
       self.make_new_branch()
@@ -262,7 +262,7 @@ class TestInstaller(DAObject):
     """Add or update one secret to the GitHub repo. """
     # Encryption by hand in case the lib gets discontinued: https://gist.github.com/plocket/af03ac9326b2ae6d36c937b125b2ea0a
     
-    if value('wants_to_set_org_secrets'):
+    if value('secrets_need') == 'org':
       # PyGithub org secrets still missing: https://github.com/PyGithub/PyGithub/issues/1373#issuecomment-856616652
       headers1, data = self.org._requester.requestJsonAndCheck(
         "GET", f"{ self.org.url }/actions/secrets/public-key"
@@ -278,7 +278,7 @@ class TestInstaller(DAObject):
         "PUT", f"{ self.org.url }/actions/secrets/{ secret_name }", input=put_parameters
       )
       
-    elif value('wants_to_set_repo_secrets'):
+    elif value('secrets_need') == 'repo':
       # https://pygithub.readthedocs.io/en/latest/github_objects/Repository.html?highlight=secret#github.Repository.Repository.create_secret
       self.repo.create_secret( secret_name, secret_value )
     

--- a/docassemble/ALAutomatedTestingTests/al_set_up_testing.py
+++ b/docassemble/ALAutomatedTestingTests/al_set_up_testing.py
@@ -76,7 +76,7 @@ class TestInstaller(DAObject):
         # TODO: Allow user to pick a custom branch name or to push to default branch?
         self.branch_name = self.get_free_branch_name()
         if self.is_repo_collaborator() and value( 'wants_to_set_repo_secrets' ):
-          self.is_repo_admin()
+          self.is_valid_repo_admin()
     
     # Set org secrets
     if ( value( 'wants_to_set_org_secrets' )):
@@ -89,19 +89,20 @@ class TestInstaller(DAObject):
   def has_right_scopes( self, scopes ):
     """Make sure the developer gave the token the right scopes"""
     # TODO: discuss: Really if just setting repo secrets, only need repo permissions, but do we want to make it that complicated/inconsistent?
-    if value('wants_to_set_org_secrets') and value('wants_to_set_up_tests'):
-      has_scopes = "admin:org" in scopes and "workflow" in scopes and "repo" in scopes
-    elif value('wants_to_set_org_secrets') and not value('wants_to_set_up_tests'):
-      has_scopes = "admin:org" in scopes
-    else:
-      has_scopes = "workflow" in scopes and "repo" in scopes
-      
-    if not has_scopes:
-      error = ErrorLikeObject( message='Incorrect Personal Access Token scopes', details=self.github_pat_scopes_error )
-      self.errors.append( error )
-      log( error.__dict__, 'console' )
-      
-    return has_scopes
+    #if value('wants_to_set_org_secrets') and value('wants_to_set_up_tests'):
+    #  has_scopes = "admin:org" in scopes and "workflow" in scopes and "repo" in scopes
+    #elif value('wants_to_set_org_secrets') and not value('wants_to_set_up_tests'):
+    #  has_scopes = "admin:org" in scopes
+    #else:
+    #  has_scopes = "workflow" in scopes and "repo" in scopes
+    #  
+    #if not has_scopes:
+    #  error = ErrorLikeObject( message='Incorrect Personal Access Token scopes', details=self.github_pat_scopes_error )
+    #  self.errors.append( error )
+    #  log( error.__dict__, 'console' )
+    #  
+    #return has_scopes
+    return True
   
   def get_repo( self, repo_url ):
     """Get repo obj of given repo. Make sure repo exists."""
@@ -149,15 +150,16 @@ class TestInstaller(DAObject):
       log( error4.__dict__, 'console' )
     return has_access
   
-  def is_repo_admin( self ):
+  def is_valid_repo_admin( self ):
     "Check that user is admin of repo."
-    role = self.repo.get_collaborator_permission( self.user_name )
-    if role != 'admin':
-      # Show error
-      error3 = ErrorLikeObject( message='Not an admin', details=self.not_org_admin_error )
-      log( error3.__dict__, 'console' )
-      self.errors.append( error3 )
-    return role != 'admin'
+    #role = self.repo.get_collaborator_permission( self.user_name )
+    #if role != 'admin':
+    #  # Show error
+    #  error3 = ErrorLikeObject( message='Not an admin', details=self.not_repo_admin_error )
+    #  log( error3.__dict__, 'console' )
+    #  self.errors.append( error3 )
+    #return role != 'admin'
+    return True
   
   def get_org( self ):
     """Return org if it exists, otherwise None."""

--- a/docassemble/ALAutomatedTestingTests/al_set_up_testing.py
+++ b/docassemble/ALAutomatedTestingTests/al_set_up_testing.py
@@ -77,7 +77,7 @@ class TestInstaller(DAObject):
         self.branch_name = self.get_free_branch_name()
         self.is_repo_collaborator()
     
-    # Set org secrets
+    # Auth for setting org secrets
     if ( value( 'wants_to_set_org_secrets' )):
       self.org = self.get_org()
       if self.org and user:

--- a/docassemble/ALAutomatedTestingTests/al_set_up_testing.py
+++ b/docassemble/ALAutomatedTestingTests/al_set_up_testing.py
@@ -65,84 +65,43 @@ class TestInstaller(DAObject):
       error1.data[ 'details' ] = self.github_token_error
       self.errors.append( error1 )
     
+    if self.user_name != '':
+      self.has_right_scopes( self.github.oauth_scopes )
+    
     # If wants to do any repo stuff. Also defines self.owner_name if it's not defined already.
     if value( 'wants_to_set_repo_secrets' ) or value( 'wants_to_set_up_tests' ):
       self.repo = self.get_repo( self.repo_url )
       if self.repo:
-        is_valid_collaborator = self.is_repo_collaborator()
-        self.is_repo_admin()
+        # TODO: Add branch name to confirmation page or final page?
+        # TODO: Allow user to pick a custom branch name or to push to default branch?
+        self.branch_name = self.get_free_branch_name()
+        if self.is_repo_collaborator() and value( 'wants_to_set_repo_secrets' ):
+          self.is_repo_admin()
     
     # Set org secrets
-    is_valid_org_admin = False
     if ( value( 'wants_to_set_org_secrets' )):
       self.org = self.get_org()
       if self.org and user:
-        is_valid_org_admin = self.is_valid_org_admin( user, self.org.login )
-        
-    #has_valid_min_repo_permissions = False
-    #if value( 'wants_to_set_repo_secrets' ):  #
-    #  if self.validate_repo():
-    #    if self.validate_repo_collaborator_auth()  # Minimum permissions required
-    #      has_valid_min_repo_permissions = True
-    #
-    #if has_valid_min_repo_permissions and value( 'wants_to_set_repo_secrets' ):
-    #  if self.validate_repo_admin_auth():
-    #    # Set repo secrets
-    #    pass
-      
-    ## Check if repo exists
-    #self.set_github_info_from_repo_url()
-    #self.repo = self.get_repo()
-    #
-    #if self.repo:
-    #  has_access = self.is_repo_collaborator()
-    #  # TODO: Allow user to pick a custom branch name or to push to default branch
-    #  self.branch_name = self.get_free_branch_name()
-    #
-    ## Give as many errors at once as is possible
-    #if len( self.errors ) > 0:
-    #  return self
+        self.is_valid_org_admin( user, self.org.login )
     
     return self
   
-  def get_org( self ):
-    """Return org if it exists, otherwise None."""
-    # Check if org exists
-    try:
-      # Trigger for authentication error or feedback for the user
-      org = self.github.get_organization( self.owner_name )
-    except Exception as error1:
-      # UnknownObjectException: 404 {"message": "Not Found", "documentation_url": "https://docs.github.com/rest/reference/orgs#get-an-organization"}
-      org = None
-      log( error1.__dict__, 'console' )
-      error1.data[ 'details' ] = self.org_does_not_exist_error
-      self.errors.append( error1 )
-    
-    return org
-    
-  def is_valid_org_admin( self, user, org_name ):
-    """Make sure org auth information is valid."""
-    valid = True
-    # Check if user belongs to org
-    try:
-      membership = user.get_organization_membership( org_name )
-      role = membership.role
-    except Exception as error2:
-      valid = False
-      role = None
-      log( error2.__dict__, 'console' )
-      error2.data[ 'details' ] = self.not_an_org_member_error
-      self.errors.append( error2 )
-
-    # Check if user is admin of org
-    if role != 'admin':
-      valid = False
-      # Show error
-      error3 = ErrorLikeObject( message='Not an admin', details=self.not_org_admin_error )
-      log( error3.__dict__, 'console' )
-      self.errors.append( error3 )
-    
-    return valid
+  def has_right_scopes( self, scopes ):
+    """Make sure the developer gave the token the right scopes"""
+    # TODO: discuss: Really if just setting repo secrets, only need repo permissions, but do we want to make it that complicated/inconsistent?
+    if value('wants_to_set_org_secrets') and value('wants_to_set_up_tests'):
+      has_scopes = "admin:org" in scopes and "workflow" in scopes and "repo" in scopes
+    elif value('wants_to_set_org_secrets') and not value('wants_to_set_up_tests'):
+      has_scopes = "admin:org" in scopes
+    else:
+      has_scopes = "workflow" in scopes and "repo" in scopes
+      
+    if not has_scopes:
+      error = ErrorLikeObject( message='Incorrect Personal Access Token scopes', details=self.github_pat_scopes_error )
+      self.errors.append( error )
+      log( error.__dict__, 'console' )
+      
+    return has_scopes
   
   def get_repo( self, repo_url ):
     """Get repo obj of given repo. Make sure repo exists."""
@@ -198,8 +157,45 @@ class TestInstaller(DAObject):
       error3 = ErrorLikeObject( message='Not an admin', details=self.not_org_admin_error )
       log( error3.__dict__, 'console' )
       self.errors.append( error3 )
-    
     return role != 'admin'
+  
+  def get_org( self ):
+    """Return org if it exists, otherwise None."""
+    # Check if org exists
+    try:
+      # Trigger for authentication error or feedback for the user
+      org = self.github.get_organization( self.owner_name )
+    except Exception as error1:
+      # UnknownObjectException: 404 {"message": "Not Found", "documentation_url": "https://docs.github.com/rest/reference/orgs#get-an-organization"}
+      org = None
+      log( error1.__dict__, 'console' )
+      error1.data[ 'details' ] = self.org_does_not_exist_error
+      self.errors.append( error1 )
+    return org
+    
+  def is_valid_org_admin( self, user, org_name ):
+    """Make sure org auth information is valid."""
+    valid = True
+    # Check if user belongs to org
+    try:
+      membership = user.get_organization_membership( org_name )
+      role = membership.role
+    except Exception as error2:
+      valid = False
+      role = None
+      log( error2.__dict__, 'console' )
+      error2.data[ 'details' ] = self.not_an_org_member_error
+      self.errors.append( error2 )
+
+    # Check if user is admin of org
+    if role != 'admin':
+      valid = False
+      # Show error
+      error3 = ErrorLikeObject( message='Not an admin', details=self.not_org_admin_error )
+      log( error3.__dict__, 'console' )
+      self.errors.append( error3 )
+    
+    return valid
   
   def get_free_branch_name( self ):
     """Return str of valid avialable branch name or None. Add appropriate errors."""
@@ -240,16 +236,18 @@ class TestInstaller(DAObject):
   # All checks should have passed at this point
   ###############################
   def update_github( self ):
-    """Update github with what it needs and make a PR."""
-    self.create_secrets()
-    #self.make_new_branch()
-    #self.push_files()
-    #self.make_pull_request()
+    """If desired, set repo or org secrets. If desired, add test files to repo."""
+    if value( 'wants_to_set_org_secrets' ) or value( 'wants_to_set_repo_secrets' ):
+      self.create_secrets()
+    if value( 'wants_to_set_up_tests' ):
+      self.make_new_branch()
+      self.push_files()
+      self.make_pull_request()
     return self
   
   def create_secrets( self ):
     """Set the GitHub repo secrets the tests need to log into the da server and
-    create projects to contain the interviews being tested. TODO: use PyGithub's secret handling https://pygithub.readthedocs.io/en/latest/github_objects/Repository.html?highlight=secret#github.Repository.Repository.create_secret. Org scope still missing: https://github.com/PyGithub/PyGithub/issues/1373#issuecomment-856616652."""
+    create projects to contain the interviews being tested. TODO: use PyGithub's secret handling ."""
     self.put_secret( 'SERVER_URL', self.server_url )
     self.put_secret( 'PLAYGROUND_EMAIL', self.email )
     self.put_secret( 'PLAYGROUND_PASSWORD', self.password )
@@ -257,15 +255,11 @@ class TestInstaller(DAObject):
     return self
   
   def put_secret( self, secret_name, secret_value ):
-    """Add or update one secret to the GitHub repo."""
+    """Add or update one secret to the GitHub repo. """
     # Encryption by hand in case the lib gets discontinued: https://gist.github.com/plocket/af03ac9326b2ae6d36c937b125b2ea0a
-    # Create repo secret: https://docs.github.com/en/rest/reference/actions#create-or-update-a-repository-secret
     
     if value('wants_to_set_org_secrets'):
-      # No PyGithub secrets for org yet
-      # by hand: https://github.com/PyGithub/PyGithub/blob/master/github/PublicKey.py#L39-L44
-      # https://github.com/PyGithub/PyGithub/blob/master/github/Repository.py#L1420-L1438
-      # https://pygithub.readthedocs.io/en/latest/github_objects/PublicKey.html
+      # PyGithub org secrets still missing: https://github.com/PyGithub/PyGithub/issues/1373#issuecomment-856616652
       headers1, data = self.org._requester.requestJsonAndCheck(
         "GET", f"{ self.org.url }/actions/secrets/public-key"
       )
@@ -281,6 +275,7 @@ class TestInstaller(DAObject):
       )
       
     elif value('wants_to_set_repo_secrets'):
+      # https://pygithub.readthedocs.io/en/latest/github_objects/Repository.html?highlight=secret#github.Repository.Repository.create_secret
       self.repo.create_secret( secret_name, secret_value )
     
     return self
@@ -289,32 +284,32 @@ class TestInstaller(DAObject):
     """Create new branch off the default branch."""
     # Get default branch
     repo = self.repo
-    default_branch_name = repo.default_branch
-    default_branch = repo.get_branch( default_branch_name )
     # Make new branch off of default branch
+    default_branch = repo.get_branch( repo.default_branch )
     ref_path = "refs/heads/" + self.branch_name
     response = repo.create_git_ref( ref_path, default_branch.commit.sha )
     
     return self
   
   def push_files( self ):
-    """Send files to folders in new branch in github.
-    https://pygithub.readthedocs.io/en/latest/examples/Repository.html#create-a-new-file-in-the-repository'''
-    # https://pygithub.readthedocs.io/en/latest/github_objects/Repository.html#github.Repository.Repository.create_file"""
+    """Send files to folders in new branch in github."""
     test_path = 'docassemble/' + self.package_name + '/data/sources/example_test.feature'
     test_commit_message = 'Add ' + test_path
+    self.send_file( '.github/workflows/run_form_tests.yml', 'Add .github/workflows/run_form_tests.yml', self.run_form_tests_str )  # 5
     self.send_file( test_path, test_commit_message, self.example_test_str )  # 2
     self.send_file( '.env_example', 'Add .env_example', self.env_example_str )  # 1
     self.send_file( '.gitignore', 'Add .gitignore', self.gitignore_str )  # 3
     self.send_file( 'package.json', 'Add package.json', self.package_json_str )  # 4
-    self.send_file( '.github/workflows/run_form_tests.yml', 'Add github/workflows/run_form_tests.yml', self.run_form_tests_str )  # 5
     return self
   
   def send_file( self, path, msg, contents ):
-    '''Either create a new file or update an existing file with the given data.
+    """Either create a new file or update an existing file with the given data.
        See https://stackoverflow.com/a/66673303/14144258.
        TODO: Discuss removing `self` to make it data-based.
-       TODO: Shall we include the committer's user name, etc?'''
+       TODO: Shall we include the committer's user name, etc?"""
+    
+    #https://pygithub.readthedocs.io/en/latest/examples/Repository.html#create-a-new-file-in-the-repository'''
+    # https://pygithub.readthedocs.io/en/latest/github_objects/Repository.html#github.Repository.Repository.create_file
     try:
       # Try to create the file
       self.repo.create_file( path, msg, contents, branch=self.branch_name )
@@ -324,11 +319,10 @@ class TestInstaller(DAObject):
         file = self.repo.get_contents( path )
         self.repo.update_file( path, msg, contents, file.sha, branch=self.branch_name )
       else:
-        # An undefined variable will make this error invisible as
-        # da has a special way of dealing with those.
+        # fyi, da will swallow an undefined variable name error
         raise error
     
-    return self;
+    return self
   
   def make_pull_request( self ):
     """Make a pull request with the new branch with changed files.

--- a/docassemble/ALAutomatedTestingTests/data/questions/al_set_up_testing.yml
+++ b/docassemble/ALAutomatedTestingTests/data/questions/al_set_up_testing.yml
@@ -42,7 +42,7 @@ code: |
     wants_to_set_up_tests
     if not defined('has_secrets'):
       has_secrets = False
-  else:
+  else:  # only contributor
     wants_to_set_org_secrets = False
     wants_to_set_repo_secrets = False
     wants_to_set_up_tests = True
@@ -55,79 +55,6 @@ code: |
   # Get file pushing permission. may need to set up token
   # If setting up files, get repo address
   
-  #if wants_to_set_up_tests and not wants_to_set_org_secrets and not wants_to_set_repo_secrets:
-  #
-  #
-  #if wants_to_set_up_tests:
-  #  # do secrets exist already?
-  #  # admins will have been asked this already
-  #  has_secrets
-  #
-  #if wants_to_set_up_tests:
-  #  if not has_secrets:
-  #    #must have secrets to set up tests kickout
-  #    pass
-  #
-  #if wants_to_set_org_secrets:
-  #  #set_org_secrets
-  #  
-  #
-  #  if not wants_to_set_org_secrets and not wants_to_set_repo_secrets:
-  #    if not existing_secrets['org'] and not existing_secrets['repo']:
-  #    if is_org_admin:
-  #      #set_org_secrets
-  #      pass
-  #    
-  #    elif is_repo_admin:
-  #      #set_repo_secrets
-  #      pass
-  #      
-  #    else:
-  #      pass
-  #      
-  #
-  #
-  #if is_org_admin:
-  #  if wants_to_set_org_secrets:
-  #    #set_org_secrets
-  #    pass
-  #  elif wants_to_set_repo_secrets:
-  #    #set_repo_secrets
-  #    pass
-  #elif is_repo_admin:
-  #  if wants_to_set_repo_secrets:
-  #    #set_repo_secrets
-  #    pass
-  #elif is_org_contributor or is_repo_contributor:
-  #  if not existing_secrets['org'] and not existing_secrets['repo']:
-  #    #no_secrets_kickout
-  #    pass
-  #
-  #
-  #if  not has_set_secrets && wants_to_set_up_tests:
-  #  pass
-  #
-  ## The tricky one is the admin who wants to set up tests, but not secrets
-  ## If admin and want to set up tests, but not want to set up secrets, ask if already has secrets (existing_secrets)
-  ## if not, set secrets
-  #
-  ##permissions_status
-  ##'contributor'
-  ##'admin'
-  ##if installer.goal == 'org_secrets':
-  ##  if permissions_status == 'admin':
-  ##    get_org_secrets_info
-  ##    set_org_secrets
-  ##  if permissions_status == 'contributor':
-  ##    need_to_be_an_org_admin
-  ##if installer.goal == 'one_package':
-  ##  if permissions_status == 'contributor':
-  ##    if part_of_an_org and (org_has_secrets_already or wants_only_repo_secrets):
-  ##      pass
-  ##    else:
-  ##      need_to_be_a_repo_admin
-  ##  # Not kicked out so far
-  ##  repo_intro
   #
   #if will_test_on_this_server:
   #  if not logged_into_test_account_on_interview_server:
@@ -162,15 +89,6 @@ code: |
   set_da_info
       
   handle_set_secrets = True
----
-code: |
-  if wants_to_set_repo_secrets:
-    #set_repo_secrets
-    pass
-  handle_repo_secrets = True
----
-code: |
-  handle_has_secrets = True
 ---
 code: |
   installer.set_org_secrets()
@@ -306,61 +224,37 @@ template: how_to_see_repo_secrets
 content: |
   To see a repository's secrets, an admin can go to the same place as where they [set the repository's secrets](https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository).
 ---
-  #- What are you setting up this time?: installer.goal
-  #  datatype: radio
-  #  choices:
-  #    - I'm setting up organization [GitHub secrets](https://docs.github.com/en/actions/reference/encrypted-secrets): org_secrets
-  #    - I'm setting up testing for one package: one_package
-  #    #- I'm setting up testing for multiple packages: multiple_packages
-  #- What kind of GitHub permissions do you have for this?: permissions_status
-  #  datatype: radio
-  #  choices:
-  #    - I am a contributor, but I do not have access to security settings: contributor
-  #    - I am an admin and have access to security settings: admin
+comment: |
+  You need to be an organization admin to set up organization secrets. Contact your admin and give them a link to this interview so they can set up the organization secrets.
+  You need to be an admin on a repository to set up automated tests. Contact your admin and give them a link to this interview so they can set up automated testing for this package.
 ---
-#if: installer.goal == 'one_package' and
-event: nothing
+id: on testing server
 question: |
-  thing
+  Before we start
 subquestion: |
+  Look at the url of this page. Is this the server where the tests will run?
+yesno: will_test_on_this_server
+---
+id: logged_into_test_account_on_interview_server
+question: |
+  What account are you logged in on?
+subquestion: |
+  Are you logged into the docassemble account where the tests will run?
+yesno: logged_into_test_account_on_interview_server
+---
+id: log_into_test_account
+question: |
+  Before you continue
+subquestion: |
+  You will probably need to log into the account where the tests will run. Since this form is on the same server and you are not logged into that account, you can do one of 3 things:
   
-  - How do you want to set up testing?: repo_scope
-    datatype: radio
-    enabled if:
-      variable: installer.goal
-      is: one_package
-    choices:
-      - As part of an organization: org
-      - Independent of an organization: independent
-  - 
-    datatype: yesno
-  
-    datatype: yesno
-    disable if:
-      variable: installer.goal
-      is: one_package
-  - note: |
-      Ask an admin in the GitHub organization if the organization already has these secrets:
-      
-      ${ secrets_list }
-      
-    show if: part_of_an_org
-  - This organization already has the necessary secrets: org_has_secrets_already
-    datatype: yesno
-    show if: org_package
-  #- Does the docassemble package or packages belong to an organization?: is_org_package
-  #  datatype: yesnomayberadio
-  #- Which of these best describes you?: type_of_org_user
-  #  show if:
-  #    variable: is_org_package
-  #    is: True
-  #  datatype: radio
-  #  choices:
-  #    - I am a GitHub contributor, but I have no access to security settings
-  #    - I am a GitHub contributor for a GitHub organization's packages, but I have no access to security settings for this package's repository: org_dev
-  #    - I am a GitHub contributor for one package's repository, but I have no access to security settings: repo_dev
-  #    - I am an admin for this package's repository and can access security settings: repo_admin
-  #    - I am an admin of this package's organization: org_admin
+  * Open an incognito window and log into that account there.
+  * Go to a different browser to log into that account.
+  * Leave this interview, log into the account, and start this interview again.
+
+  Tap to continue when you have done one of those.
+
+continue button field: log_into_test_account
 ---
 id: org secrets
 #if: installer.goal == 'org_secrets' and permissions_status == 'admin'
@@ -395,25 +289,6 @@ fields:
       We also need the GitHub organizatoin name with correct capitalization. Example:[BR]
       `SuffolkLITLab`
   - Organization: installer.owner_name
----
-id: not org admin kickout
-event: need_to_be_an_org_admin
-question: |
-  You need to be an admin
-subquestion: |
-  You need to be an organization admin to set up organization secrets. Contact your admin and give them a link to this interview so they can set up the organization secrets.
----
-id: non admin repo questions
-question: |
-  Where will your secrets be?
-  part_of_an_org and (org_has_secrets_already or wants_only_repo_secrets)
----
-id: non admin repo kickout
-event: need_to_be_a_repo_admin
-question: |
-  You need to be an admin
-subquestion: |
-  You need to be an admin on a repository to set up automated tests. Contact your admin and give them a link to this interview so they can set up automated testing for this package.
 ---
 # TODO: Add link to docs where we explain how the library makes a project, etc.
 # TODO: Add links to the actual github repo and files and folders
@@ -466,34 +341,6 @@ content: |
   * PLAYGROUND_EMAIL
   * PLAYGROUND_PASSWORD
   * PLAYGROUND_ID
----
-id: on testing server
-question: |
-  Before we start
-subquestion: |
-  Look at the url of this page. Is this the server where the tests will run?
-yesno: will_test_on_this_server
----
-id: logged_into_test_account_on_interview_server
-question: |
-  What account are you logged in on?
-subquestion: |
-  Are you logged into the docassemble account where the tests will run?
-yesno: logged_into_test_account_on_interview_server
----
-id: log_into_test_account
-question: |
-  Before you continue
-subquestion: |
-  You will probably need to log into the account where the tests will run. Since this form is on the same server and you are not logged into that account, you can do one of 3 things:
-  
-  * Open an incognito window and log into that account there.
-  * Go to a different browser to log into that account.
-  * Leave this interview, log into the account, and start this interview again.
-
-  Tap to continue when you have done one of those.
-
-continue button field: log_into_test_account
 ---
 id: org secrets info
 question: |

--- a/docassemble/ALAutomatedTestingTests/data/questions/al_set_up_testing.yml
+++ b/docassemble/ALAutomatedTestingTests/data/questions/al_set_up_testing.yml
@@ -41,31 +41,28 @@ code: |
   if is_org_admin or is_repo_admin:
     wants_to_set_up_tests
     if not defined('has_secrets'):
-      has_secrets = False
-  else:  # only contributor
+      has_secrets = DADict('has_secrets', there_are_any=False)  # None are true
+  else:  # non-admins
     wants_to_set_org_secrets = False
     wants_to_set_repo_secrets = False
     wants_to_set_up_tests = True
     # DO NOT define has_secrets
   
-  if not has_secrets:
-    get_secrets
+  # Everyone has to set up secrets if they don't have them
+  if not has_secrets.any_true():
+    if not is_org_admin or is_repo_admin:
+      needs_secrets_kickout
+    # Otherwise carry on
+    get_secrets_info
   
-  # Get file pushing permission. may need to set up token
-  # If setting up files, get repo address
-  
+  ## Get github token. Different wording for contributor vs. admin
+  #installer.token
+  #set_github_auth
   #
-  #if will_test_on_this_server:
-  #  if not logged_into_test_account_on_interview_server:
-  #    log_into_test_account
+  ## If setting up test files, get repo address
+  
+  
   ##
-  ### da stuff
-  ##installer.password
-  ##set_da_info
-  ##
-  ### github stuff
-  ##installer.token
-  ##set_github_auth
   ##
   ### confirm
   ##is_ready
@@ -79,7 +76,6 @@ code: |
   force_ask( 'next_steps_org' )
 ---
 code: |
-  
   if will_test_on_this_server:
     if not logged_into_test_account_on_interview_server:
       log_into_test_account
@@ -87,7 +83,7 @@ code: |
   installer.password
   set_da_info
       
-  get_secrets = True
+  get_secrets_info = True
 ---
 code: |
   installer.set_da_info()
@@ -126,6 +122,8 @@ question: |
 subquestion: |
   This tool helps developers or organizations set up automated integrated testing for docassemble packages that have a GitHub repository.
   
+  :clock: This task can take up to 30 minutes.
+  
   What you can do depends on your situation and what kind of GitHub permissions you have.
   
   Which descriptions fit you? Pick at least one.
@@ -150,7 +148,7 @@ id: admin goal
 question: |
   What do you want to do?
 subquestion: |
-  These tests need to make a Project on your docassemble server and then run an interview from that Project. [GitHub secrets](https://docs.github.com/en/actions/reference/encrypted-secrets) store and encrypt the information the tests need in order to do that. The tests need these secrets:
+  For tests to run, they need to be able to make a Project on your docassemble server and then run an interview from that Project. [GitHub secrets](https://docs.github.com/en/actions/reference/encrypted-secrets) store and encrypt the information the tests need in order to do that. You can use this tool to set these secrets:
   
   ${ secrets_list }
   
@@ -184,8 +182,11 @@ fields:
   - note: A package must have access to GitHub secrets in order to run tests.
     js show if: |
       val('wants_to_set_up_tests') && !val('wants_to_set_repo_secrets') && !val('wants_to_set_org_secrets')
-  - The package already has access to organization or repository secrets: has_secrets
-    datatype: yesnowide
+  - no label: has_secrets
+    datatype: checkboxes
+    none of the above: False
+    choices:
+      - The package already has access to organization or repository secrets: yes
     help: |
       ${ how_to_see_repo_secrets } (see above for link)
     js show if: |
@@ -196,7 +197,7 @@ validation code: |
         or not wants_to_set_org_secrets)
       and (not defined('wants_to_set_repo_secrets')
         or not wants_to_set_repo_secrets)
-      and not has_secrets):
+      and not has_secrets.any_true()):
     validation_error("If you want to set up tests and the package does not have access to secrets, you must choose a way to set secrets.")
   if (not wants_to_set_up_tests
       and (not defined('wants_to_set_org_secrets')
@@ -206,12 +207,13 @@ validation code: |
     validation_error("You must mark at least one choice.")
   # Make sure has_secrets is defined in this validation code?
 ---
-# If non-admin and want to set up testing
 id: which secrets exist non-admin
 question: |
   GitHub secrets
 subquestion: |
-  For tests to work, a repository needs access to [GitHub secrets](https://docs.github.com/en/actions/reference/encrypted-secrets) set by the organization or repo admin. What is the status of the secrets now? If you don't know, ask the admin of the organization or repository if these secrets are set:
+  For tests to run, a repository needs access to [GitHub secrets](https://docs.github.com/en/actions/reference/encrypted-secrets) set by the organization or repo admin. We need to know the status of the secrets.
+  
+  If they are not set yet, give the admin the link to this form. If you don't know, ask the admin of the organization or repository if these secrets are set:
 
   ${ secrets_list }
   
@@ -219,13 +221,11 @@ subquestion: |
   
   Does the package have access to those secrets?
 fields:
-  - The repository has access to organization secrets: has_secrets
-    datatype: yesnowide
-  - The repository has access to repository secrets: has_secrets
-    datatype: yesnowide
-validation code: |
-  if not has_secrets:
-    validation_error("The package must have access to these secrets for you to continue setting up tests.")
+  - no label: has_secrets
+    datatype: checkboxes
+    choices:
+      - The repository has access to organization secrets: org
+      - The repository has access to repository secrets: repo
 ---
 template: how_to_see_repo_secrets
 content: |
@@ -235,9 +235,12 @@ template: check_secrets_access
 content: |
   If the organization has these secrets, but those secrets are not showing up in the package's repository, the admin may need to [change the access levels for the secret](https://docs.github.com/en/actions/reference/encrypted-secrets#reviewing-access-to-organization-level-secrets).
 ---
-comment: |
-  You need to be an organization admin to set up organization secrets. Contact your admin and give them a link to this interview so they can set up the organization secrets.
-  You need to be an admin on a repository to set up automated tests. Contact your admin and give them a link to this interview so they can set up automated testing for this package.
+id: no admin or secrets kickout
+event: needs_secrets_kickout
+question: |
+  The repository needs secrets
+subquestion: |
+  To get these tests to run, an admin needs to set up secrets. Contact your admin and give them a link to this interview. It will help them set up the right secrets.
 ---
 id: on testing server
 question: |
@@ -267,15 +270,43 @@ subquestion: |
 
 continue button field: log_into_test_account
 ---
-id: org secrets
+id: da server info
+question: |
+  GitHub secrets
+subquestion: |
+  As described, the tests need access to server login information. This tool will help you set up these encrypted [GitHub secrets](https://docs.github.com/en/actions/reference/encrypted-secrets):
+  
+  ${ secrets_list }
+
+  If you have not already done so:
+  
+  1. Decide on the docassemble account where the tests will run.
+  1. Make sure you are logged in there.
+  1. Answer the questions below for that account. If you want to use your own account, put your own docassemble email and password below.
+fields:
+  - Email: installer.email
+    datatype: email
+  - Password: installer.password
+    datatype: password
+  - note: |
+      Go to the Playground of the account and run any working YAML file. For example, test.yml. What is the URL in the address bar? Example:[BR]
+      `https://legal-dev.org/interview?i=docassemble.playground22%3Atest.yml`
+  - URL: installer.playground_url
+    hint: https://legal-dev.org/interview?i=docassemble.playground22%3Atest.yml
+
+auto terms:
+  - the URL in the address bar: |
+      The interview URL will give us the account's Playground ID and the address of the server that the account is on.
+---
+id: org github auth
 #if: installer.goal == 'org_secrets' and permissions_status == 'admin'
 continue button field: get_org_secrets_info
 question: |
-  Setting up GitHub secrets for your organization
+  Setting up GitHub secrets
 subquestion: |
   [Organization-wide secrets](https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-an-organization) will allow any of your contributors to very easily add automated testing to any of your organization's packages. If they can push to the repository, they can set up testing for it.
 
-  :clock: This could take about 10 minutes
+  :clock: Setting up secrets could take about 20 minutes
   
   ---
   
@@ -284,8 +315,6 @@ subquestion: |
   ${ secrets_list }
   
   ---
-  
-  You must be an admin on the GitHub organization so you can temporarily give this tool permission to create secrets. Once you are logged into GitHub as an admin:
   
   1. Start making a [personal access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) for your GitHub account. You will be able to delete it after you are finished here.
   1. Tap the checkbox for "admin:org" permissions.
@@ -300,101 +329,6 @@ fields:
       We also need the GitHub organizatoin name with correct capitalization. Example:[BR]
       `SuffolkLITLab`
   - Organization: installer.owner_name
----
-# TODO: Add link to docs where we explain how the library makes a project, etc.
-# TODO: Add links to the actual github repo and files and folders
-# TODO: only show 'other than you' if the person is logged in
-id: intro personal repo
-question: |
-  Set up Document Assembly Line automated integrated testing
-subquestion: |
-  This interview will help you set up automated integrated GitHub testing for a docassemble package.
-
-  :clock: This could take about 40 minutes
-  
-  ---
-  
-  **Make sure:**
-  
-  * The package is in a GitHub repository.
-  * You have admin permissions on the package's GitHub repository.
-  * You are logged into the docassemble account where the tests will run.
-  
-  ---
-
-  **Sneak Peak**
-
-  This tool will add folders and files to the project:
-
-  ${ files_list }
-  
-  It will add 3 [GitHub "SECRETS"](https://docs.github.com/en/actions/reference/encrypted-secrets) to the repository to store encrypted information safely:
-  
-  ${ secrets_list }
-  
-  ---
-  
-  Your answers will be encrypted end-to-end and on the server. No one other than you will have access to them.
-  
-continue button field: repo_intro
----
-template: files_list
-content: |
-  * `tests/features/example_test.feature` is a very simple example of a test.
-  * `.github/workflows/run_interview_tests.yml` tells GitHub when and how to run the tests.
-  * `package.json` lets GitHub load other packages it needs to run the tests.
-  * `.gitignore` is for developers who want to work in their local environment.
-  * `.env-example` can help guide developers who want to work in their local environment to set up the environment variables.
----
-template: secrets_list
-content: |
-  * SERVER_URL
-  * PLAYGROUND_EMAIL
-  * PLAYGROUND_PASSWORD
-  * PLAYGROUND_ID
----
-id: org secrets info
-question: |
-  Docassemble
-subquestion: |
-  Tests will create Projects in an account on your docassemble server, pull in the GitHub code, and run the interviews.
-  
-  Decide on the docassemble account where the tests will run. Answer the questions below for the account. If you want to use your own account, put your own docassemble email and password below.
-fields:
-  - Account email: installer.email
-    datatype: email
-  - Account password: installer.password
-    datatype: password
-  - note: |
-      What is the address of your docassemble server? Example:[BR]
-      `https://dev.legal-help.org`
-  - no label: installer.server_url
-auto terms:
-  - the URL in the address bar: |
-      The interview URL will give us the account's Playground ID and the address of the server that the account is on.
----
-id: server info
-question: |
-  Docassemble
-subquestion: |
-  These tests will create Projects in an account on your docassemble server, pull in the GitHub code, and run the interviews. To do that, they need docassemble login information. This is what will be in the encrypted GitHub secrets.
-  
-  1. Decide on the docassemble account where the tests will run
-  1. Make sure you are logged into that account.
-  1. Answer the questions below for the docassemble account that will run tests. If you want to use your own account, put your own docassemble email and password below.
-  
-fields:
-  - Email: installer.email
-    datatype: email
-  - Password: installer.password
-    datatype: password
-  - note: |
-      Go to the Playground of the account and run any working YAML file. For example, test.yml. What is the URL in the address bar? Example:[BR]
-      `https://dev.legal.org/interview?i=docassemble.playground22%3Atest.yml`
-  - URL: installer.playground_url
-auto terms:
-  - the URL in the address bar: |
-      The interview URL will give us the account's Playground ID and the address of the server that the account is on.    
 ---
 # TODO: Add instructions on how to find the GitHub repo url on Packages page (maybe point to docs)
 id: github auth
@@ -418,6 +352,58 @@ fields:
   - GitHub URL: installer.repo_url
     help: |
       The repository's URL will give us the name of the repo and its owner.
+---
+## TODO: Add link to docs where we explain how the library makes a project, etc.
+## TODO: Add links to the actual github repo and files and folders
+## TODO: only show 'other than you' if the person is logged in
+#id: intro personal repo
+#question: |
+#  Set up Document Assembly Line automated integrated testing
+#subquestion: |
+#  This interview will help you set up automated integrated GitHub testing for a docassemble package.
+#
+#  :clock: This could take about 40 minutes
+#  
+#  ---
+#  
+#  **Make sure:**
+#  
+#  * The package is in a GitHub repository.
+#  * You have admin permissions on the package's GitHub repository.
+#  * You are logged into the docassemble account where the tests will run.
+#  
+#  ---
+#
+#  **Sneak Peak**
+#
+#  This tool will add folders and files to the project:
+#
+#  ${ files_list }
+#  
+#  It will add 3 [GitHub "SECRETS"](https://docs.github.com/en/actions/reference/encrypted-secrets) to the repository to store encrypted information safely:
+#  
+#  ${ secrets_list }
+#  
+#  ---
+#  
+#  Your answers will be encrypted end-to-end and on the server. No one other than you will have access to them.
+#  
+#continue button field: repo_intro
+---
+template: files_list
+content: |
+  * `tests/features/example_test.feature` is a very simple example of a test.
+  * `.github/workflows/run_interview_tests.yml` tells GitHub when and how to run the tests.
+  * `package.json` lets GitHub load other packages it needs to run the tests.
+  * `.gitignore` is for developers who want to work in their local environment.
+  * `.env-example` can help guide developers who want to work in their local environment to set up the environment variables.
+---
+template: secrets_list
+content: |
+  * PLAYGROUND_EMAIL
+  * PLAYGROUND_PASSWORD
+  * PLAYGROUND_ID
+  * SERVER_URL
 ---
 id: confirm info
 question: |

--- a/docassemble/ALAutomatedTestingTests/data/questions/al_set_up_testing.yml
+++ b/docassemble/ALAutomatedTestingTests/data/questions/al_set_up_testing.yml
@@ -31,9 +31,11 @@ comment: |
 ---
 mandatory: True
 code: |
-  ## for dev
+  # for dev
   #installer.repo_url = 'https://github.com/plocket/install'
-  #installer.playground_url = 'https://apps-dev.suffolklitlab.org/interview?i=docassemble.playground12ALTestingGHSendFiles%3Aal_set_up_testing.yml#page4'
+  installer.playground_url = 'https://apps-dev.suffolklitlab.org/interview?i=docassemble.playground12ALTestingGHSendFiles%3Aal_set_up_testing.yml#page4'
+  installer.email = 'a@example.com'
+  installer.password = 'asldkjflsdkjfldsjflsdjf'
   
   # show errors first thing on each loop
   if len( installer.errors ) > 0:
@@ -52,7 +54,7 @@ code: |
   
   # Everyone has to set up secrets if they don't have them
   if not has_secrets.any_true():
-    if not is_org_admin or is_repo_admin:
+    if not is_org_admin and not is_repo_admin:
       needs_secrets_kickout
     # Otherwise carry on
     get_secrets_info
@@ -622,7 +624,7 @@ code: |
 ---
 template: github_access_error
 content: |
-  The user **${ installer.user_name }** does not have admin access to change the files or ["SECRETS"](https://docs.github.com/en/actions/reference/encrypted-secrets) in the **${ installer.repo_name }** repository owned by the owner **${ installer.owner_name }**. You can ask the admin to give correct access.
+  The user **${ installer.user_name }** does not have collaborator access to change the files in the **${ installer.repo_name }** repository owned by the owner **${ installer.owner_name }**. You can ask the admin to give correct access.
 ---
 depends on: github_branch_name_error
 code: |

--- a/docassemble/ALAutomatedTestingTests/data/questions/al_set_up_testing.yml
+++ b/docassemble/ALAutomatedTestingTests/data/questions/al_set_up_testing.yml
@@ -63,8 +63,6 @@ code: |
   installer.token
   set_github_auth
   
-  ## If setting up test files, get repo address
-  
   # TODO: next steps for secrets - ensure the secret has the access settings you want
   
   ##
@@ -103,9 +101,7 @@ code: |
   set_org_secrets = True
 ---
 code: |
-  if 'wants_to_set_org_secrets' or 'wants_to_set_repo_secrets':
-    installer.create_secrets()
-  if False:
+  if wants_to_set_up_tests:
     # These vars need to be defined before creating a branch.
     # Otherwise, because of da execution behavior, they cause
     # loops that end up creating 5 branches. It seemed to make
@@ -115,7 +111,8 @@ code: |
     installer.gitignore_str = installer.gitignore.content
     installer.package_json_str = installer.package_json.content
     installer.run_form_tests_str = installer.run_form_tests.content
-    installer.update_github()
+    
+  installer.update_github()
   update_github = True
 ---
 auto terms:
@@ -249,7 +246,7 @@ content: |
 ---
 template: check_secrets_access
 content: |
-  If the organization has these secrets, but those secrets are not showing up in the package's repository, the admin may need to [change the access levels for the secret](https://docs.github.com/en/actions/reference/encrypted-secrets#reviewing-access-to-organization-level-secrets).
+  If the organization has these secrets, but those secrets are not showing up in the package's repository, the admin may need to [change the access settings for the secret](https://docs.github.com/en/actions/reference/encrypted-secrets#reviewing-access-to-organization-level-secrets).
 ---
 id: no admin or secrets kickout
 event: needs_secrets_kickout
@@ -325,11 +322,9 @@ subquestion: |
   1. Start making a [personal access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token). You will be able to delete it after you are finished here.
   % if wants_to_set_org_secrets:
   1. Tap the checkbox for "admin:org" permissions.
-  % elif wants_to_set_repo_secrets:
-  1. Tap the checkbox for "workflow" permissions. That should also trigger "repo" permissions.
   % endif
-  % if wants_to_set_up_tests and not wants_to_set_repo_secrets:
-  1. Tap the checkbox for "repo" permissions.
+  % if wants_to_set_up_tests or wants_to_set_repo_secrets:
+  1. Tap the checkbox for "workflow" permissions. That should also trigger "repo" permissions.
   % endif
   1. Finish creating the token.
   1. Copy the token and paste it below.
@@ -337,7 +332,7 @@ fields:
   - Personal access token: installer.token
     datatype: password
     help: |
-      The token must have ${ token_permissions_level } permissions.
+      The token must have ${ token_permissions_scope } permissions.
   - note: |
       We also need the GitHub repository URL of the package. Example:[BR]
       `https://github.com/TheLawFantastic/docassemble-GreatForm`
@@ -361,16 +356,15 @@ fields:
       code: |
         not wants_to_set_up_tests and wants_to_set_org_secrets
 ---
-template: token_permissions_level
+# TODO: discuss: Really if just setting repo secrets, only need repo permissions, but do we want to make it that complicated/inconsistent?
+template: token_permissions_scope
 content: |
-  % if wants_to_set_up_tests and wants_to_set_org_secrets:
-  "admin:org" and "repo"
-  % elif wants_to_set_org_secrets:
+  % if wants_to_set_org_secrets and wants_to_set_up_tests:
+  "admin:org", "workflow", and "repo"
+  % elif wants_to_set_org_secrets and not wants_to_set_up_tests:
   "admin:org"
-  % elif wants_to_set_repo_secrets:
-  "workflow"
   % else:
-  "repo"
+  "workflow" and "repo"
   % endif
 ---
 ## TODO: Add link to docs where we explain how the library makes a project, etc.
@@ -567,6 +561,22 @@ content: |
   `https://dev.court-wizards.org/interview?i=docassemble.playground222ProjectName%3Asome_file.yml` [BR]
   If you are sure you have the whole URL of a running interview, please [file an issue](https://github.com/plocket/docassemble-ALAutomatedTestingTests) and include your interview URL in the report.
 ---
+depends on: github_pat_scopes_error
+code: |
+  installer.github_pat_scopes_error = github_pat_scopes_error.content
+---
+template: github_pat_scopes_error
+content: |
+  The permission scope(s) of that [Github personal access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) are **${ comma_and_list( installer.github.oauth_scopes ) }**. What you are trying to do needs ${ token_permissions_scope } scope(s). You can try copying and pasting the token again or you can try [making a new one](https://github.com/settings/tokens). (This did not follow plain language guidelines, sorry)
+---
+depends on: github_token_error
+code: |
+  installer.github_token_error = github_token_error.content
+---
+template: github_token_error
+content: |
+  The permission scope of that [Github personal access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) are not sufficient. Are you sure it has ${ token_permissions_scope } scope permissions? You can try copying and pasting it again or you can try [making a new one](https://github.com/settings/tokens).
+---
 depends on: github_url_error
 code: |
   installer.github_url_error = github_url_error.content
@@ -578,14 +588,6 @@ content: |
   `https://github.com/owner_name/repo_name`
   
   If you are sure you have the correct GitHub URL, please [file an issue](https://github.com/plocket/docassemble-ALAutomatedTestingTests) and include the GitHub URL.
----
-depends on: github_token_error
-code: |
-  installer.github_token_error = github_token_error.content
----
-template: github_token_error
-content: |
-  The permission levels of that [Github personal access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) are not sufficient. Are you sure it has 'repo' and 'workflow' level permissions? You can try copying and pasting it again or you can try [making a new one](https://github.com/settings/tokens).
 ---
 depends on: org_does_not_exist_error
 code: |

--- a/docassemble/ALAutomatedTestingTests/data/questions/al_set_up_testing.yml
+++ b/docassemble/ALAutomatedTestingTests/data/questions/al_set_up_testing.yml
@@ -57,10 +57,10 @@ code: |
     # Otherwise carry on
     get_secrets_info
   
-  # Get github token. Different wording for different goals
+  # Get and test github PAT (token) and either repo url or org name
   installer.token
-  #set_github_auth
-  #
+  set_github_auth
+  
   ## If setting up test files, get repo address
   
   # TODO: next steps for secrets - ensure the secret has the access settings you want
@@ -84,7 +84,7 @@ code: |
       log_into_test_account
       
   installer.password
-  #set_da_info
+  set_da_info
       
   get_secrets_info = True
 ---
@@ -93,12 +93,12 @@ code: |
   set_da_info = True
 ---
 code: |
-  installer.set_org_secrets()
-  set_org_secrets = True
----
-code: |
   installer.set_github_auth()
   set_github_auth = True
+---
+code: |
+  installer.set_org_secrets()
+  set_org_secrets = True
 ---
 code: |
   # These vars need to be defined before creating a branch.
@@ -302,7 +302,7 @@ fields:
   - note: |
       Go to the Playground of the account and run any working YAML file. For example, test.yml. What is the URL in the address bar? Example:[BR]
       `https://legal-dev.org/interview?i=docassemble.playground22%3Atest.yml`
-  - URL: installer.playground_url
+  - Interview URL: installer.playground_url
     hint: https://legal-dev.org/interview?i=docassemble.playground22%3Atest.yml
 
 auto terms:
@@ -576,6 +576,30 @@ code: |
 template: github_token_error
 content: |
   The permission levels of that [Github personal access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) are not sufficient. Are you sure it has 'repo' and 'workflow' level permissions? You can try copying and pasting it again or you can try [making a new one](https://github.com/settings/tokens).
+---
+depends on: org_does_not_exist_error
+code: |
+  installer.org_does_not_exist_error = org_does_not_exist_error.content
+---
+template: org_does_not_exist_error
+content: |
+  GitHub cannot find an organization called **${ installer.owner_name }**. 
+---
+depends on: not_an_org_member_error
+code: |
+  installer.not_an_org_member_error = not_an_org_member_error.content
+---
+template: not_an_org_member_error
+content: |
+  **${ installer.user_name }** might not be a member of **${ installer.owner_name }**. Try double checking the names.
+---
+depends on: not_org_admin_error
+code: |
+  installer.not_org_admin_error = not_org_admin_error.content
+---
+template: not_org_admin_error
+content: |
+  **${ installer.user_name }** might not be an admin of **${ installer.owner_name }**. Try double checking the names.
 ---
 depends on: github_repo_not_found_error
 code: |

--- a/docassemble/ALAutomatedTestingTests/data/questions/al_set_up_testing.yml
+++ b/docassemble/ALAutomatedTestingTests/data/questions/al_set_up_testing.yml
@@ -314,6 +314,7 @@ auto terms:
   - the URL in the address bar: |
       The interview URL will give us the account's Playground ID and the address of the server that the account is on.
 ---
+# TODO: Can an org admin sometimes not have push access to an org repo?
 id: github auth
 question: |
   Authorizing for GitHub
@@ -321,7 +322,7 @@ subquestion: |
   You now need to create temporary authorization for GitHub using a [personal access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token).
   
   1. Start making a [personal access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token). You will be able to delete it after you are finished here.
-  % elif wants_to_set_org_secrets:
+  % if wants_to_set_org_secrets:
   1. Tap the checkbox for "admin:org" permissions.
   % elif wants_to_set_repo_secrets:
   1. Tap the checkbox for "workflow" permissions. That should also trigger "repo" permissions.

--- a/docassemble/ALAutomatedTestingTests/data/questions/al_set_up_testing.yml
+++ b/docassemble/ALAutomatedTestingTests/data/questions/al_set_up_testing.yml
@@ -6,6 +6,7 @@ metadata:
 ---
 features:
   question back button: True
+  question help button: True
   css:
     - styles.css
 ---
@@ -29,32 +30,22 @@ comment: |
 ---
 mandatory: True
 code: |
-  # for dev
-  #installer.repo_url = 'https://github.com/plocket/install'
-  installer.playground_url = 'https://apps-dev.suffolklitlab.org/interview?i=docassemble.playground12ALTestingGHSendFiles%3Aal_set_up_testing.yml#page4'
-  installer.email = 'a@example.com'
-  installer.password = 'asldkjflsdkjfldsjflsdjf'
+  ## for dev
+  ##installer.repo_url = 'https://github.com/plocket/install'
+  #installer.playground_url = 'https://apps-dev.suffolklitlab.org/interview?i=docassemble.playground12ALTestingGHSendFiles%3Aal_set_up_testing.yml#page4'
+  #installer.email = 'a@example.com'
+  #installer.password = 'asldkjflsdkjfldsjflsdjf'
   
   # show errors first thing on each loop
   if len( installer.errors ) > 0:
     show_errors
   
-  # Secrets
-  if is_org_admin or is_repo_admin:
-    wants_to_set_up_tests
-    if not defined('has_secrets'):
-      has_secrets = DADict('has_secrets', there_are_any=False)  # None are true
-  else:  # non-admins
-    wants_to_set_org_secrets = False
-    wants_to_set_repo_secrets = False
-    wants_to_set_up_tests = True
-    # DO NOT define has_secrets
+  # role and goal
+  is_org_admin
+  wants_to_set_up_tests
   
-  # Everyone has to set up secrets if they don't have them
-  if not has_secrets.any_true():
-    if not is_org_admin and not is_repo_admin:
-      needs_secrets_kickout
-    # Otherwise carry on
+  # Secrets
+  if wants_to_set_org_secrets or wants_to_set_repo_secrets:
     get_secrets_info
   
   # Get and test github PAT (token) and either repo url or org name
@@ -66,7 +57,6 @@ code: |
   # update github
   update_github
   
-  #instructions
   force_ask( 'next_steps' )
 ---
 code: |
@@ -121,38 +111,18 @@ subquestion: |
   :clock: This task can take up to 30 minutes.
   
   What you can do depends on your situation and what kind of GitHub permissions you have.
-  
-  Which descriptions fit you? Pick at least one.
 fields:
-  - I am an admin of the GitHub organization with access to security settings: is_org_admin
-    datatype: yesnowide
-    default: false
-  - I am a collaborator of the GitHub organization WITHOUT access to security settings: is_org_collaborator
-    datatype: yesnowide
-  - I am an admin of the package's GitHub repository with access to security settings: is_repo_admin
-    datatype: yesnowide
-  - I am a collaborator to the package's GitHub repository WITHOUT access to security settings: is_repo_collaborator
-    datatype: yesnowide
-validation code: |
-  if (not is_org_admin
-      and not is_org_collaborator
-      and not is_repo_admin
-      and not is_repo_collaborator):
-    validation_error("You cannot set up tests if you don't have at least one of these roles.")
+  - Are you the admin of the organization?: is_org_admin
+    datatype: yesnoradio
 ---
+# Note: any repo writer can set repo secrets
 id: admin goal
 question: |
   What do you want to do?
 subquestion: |
-  For tests to run, they need to be able to make a Project on your docassemble server and then run an interview from that Project. [GitHub secrets](https://docs.github.com/en/actions/reference/encrypted-secrets) store and encrypt the information the tests need in order to do that. This interview will help you set these secrets:
+  For tests to run, they need to be able to autmoatically make a Project on your docassemble server and then run an interview from that Project. To do that, the repository need access to organization or repository secrets and some extra files. Once an organization admin sets up organization secrets, repository secrets are unnecessary.
   
-  ${ secrets_list }
-  
-  Once an organization admin sets up secrets, repository secrets will be unnecessary and any developer that can push to a repository can set up automated tests for it with no other special permissions.
-  
-  ${ how_to_see_repo_secrets }
-  
-  ${ check_secrets_access }
+  This tool can help set up secrets, add testing files to a repository, or both. If you might need to add secrets, tap the "About Github secrets" help button at the bottom of the page to learn more.
   
   What do you want to do?
 fields:
@@ -171,8 +141,16 @@ fields:
         is_org_admin
     js enable if: |
       !val('wants_to_set_org_secrets')
+  # Not org admin
+  - I want to set or update the repository's secrets: wants_to_set_repo_secrets
+    datatype: yesnowide
+    show if:
+      code: |
+        not is_org_admin
+  # Always
   - I want to set up testing for a package: wants_to_set_up_tests
     datatype: yesnowide
+  # Is org admin
   - note: A package must have access to GitHub secrets in order to run tests.
     show if:
       code: |
@@ -184,19 +162,13 @@ fields:
     none of the above: False
     choices:
       - The package already has access to organization or repository secrets: yes
-    help: |
-      ${ how_to_see_repo_secrets } (see above for link)
+    help: Tap the "About Github secrets" help button for more info
     show if:
       code: |
         is_org_admin
     js show if: |
       val('wants_to_set_up_tests') && !val('wants_to_set_repo_secrets') && !val('wants_to_set_org_secrets')
   # Not org admin
-  - I want to set or update the repository's secrets: wants_to_set_repo_secrets
-    datatype: yesnowide
-    show if:
-      code: |
-        not is_org_admin
   - note: A package must have access to GitHub secrets in order to run tests.
     show if:
       code: |
@@ -208,8 +180,7 @@ fields:
     none of the above: False
     choices:
       - The package already has access to organization or repository secrets: yes
-    help: |
-      ${ how_to_see_repo_secrets } (see above for link)
+    help: Tap the "About Github secrets" help button for more info
     show if:
       code: |
         not is_org_admin
@@ -236,34 +207,24 @@ validation code: |
       and not wants_to_set_org_secrets
       and not wants_to_set_repo_secrets):
     validation_error("You must mark at least one choice.")
----
-id: which secrets exist non-admin
-question: |
-  GitHub secrets
-subquestion: |
-  For tests to run, a repository needs access to [GitHub secrets](https://docs.github.com/en/actions/reference/encrypted-secrets) set by the organization or repo admin. We need to know the status of the secrets.
-  
-  If they are not set yet, give the admin the link to this form. If you don't know, ask the admin of the organization or repository if these secrets are set:
+help:
+  label: |
+    About GitHub secrets
+  content: |
+    **About GitHub secrets:**
 
-  ${ secrets_list }
+    [GitHub secrets](https://docs.github.com/en/actions/reference/encrypted-secrets) store and encrypt the information the tests need in order to autmoatically make a Project on your docassemble server and then run an interview from that Project. This tool can help you set these secrets:
+
+    ${ secrets_list }
+    
+    If you're not sure what your organization secrets are, an org admin can [see them in the same place that they can create them](https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-an-organization).
+    
+    If you're not sure what your repository secrets are, a repository admin can [see them in the same place that they can create them](https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository).
+    
+    If you're not sure whether a repository has access to an organization's secrets, a repository admin can see those on the repository's secrets page too (described above).
+    
+    If the organization has these secrets, but those secrets are not showing up in the package's repository, the organization admin may need to [change the access settings for the secret](https://docs.github.com/en/actions/reference/encrypted-secrets#reviewing-access-to-organization-level-secrets).
   
-  ${ how_to_see_repo_secrets } ${ check_secrets_access }
-  
-  Does the package have access to those secrets?
-fields:
-  - no label: has_secrets
-    datatype: checkboxes
-    choices:
-      - The repository has access to organization secrets: org
-      - The repository has access to repository secrets: repo
----
-template: how_to_see_repo_secrets
-content: |
-  To see a repository's secrets, an admin can go to the same place as where they [set the repository's secrets](https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository).
----
-template: check_secrets_access
-content: |
-  If the organization has these secrets, but those secrets are not showing up in the package's repository, the admin may need to [change the access settings for the secret](https://docs.github.com/en/actions/reference/encrypted-secrets#reviewing-access-to-organization-level-secrets).
 ---
 id: no admin or secrets kickout
 event: needs_secrets_kickout
@@ -314,12 +275,12 @@ subquestion: |
   1. Make sure you are logged in there.
   1. Answer the questions below for that account. If you want to use your own account, put your own docassemble email and password below.
 fields:
-  - Email: installer.email
+  - Account email: installer.email
     datatype: email
-  - Password: installer.password
+  - Account password: installer.password
     datatype: password
   - note: |
-      Go to the Playground of the account and run any working YAML file. For example, test.yml. What is the URL in the address bar? Example:[BR]
+      Go to the Playground of the account and run any working YAML file. For example, **test.yml**. What is the URL in the address bar? Example:[BR]
       `https://legal-dev.org/interview?i=docassemble.playground22%3Atest.yml`
   - Interview URL: installer.playground_url
     hint: https://legal-dev.org/interview?i=docassemble.playground22%3Atest.yml
@@ -431,11 +392,11 @@ content: |
 ---
 template: files_list
 content: |
-  * tests/features/example_test.feature is a very simple example of a test.
-  * .github/workflows/run_interview_tests.yml tells GitHub when and how to run the tests and save the files created.
-  * package.json lets GitHub load other packages it needs to run the tests.
-  * .gitignore is for developers who want to work in their local environment.
-  * .env-example can help guide developers who want to work in their local environment to set up the environment variables.
+  * **tests/features/example_test.feature** is a very simple example of a test.
+  * **.github/workflows/run_interview_tests.yml** tells GitHub when and how to run the tests and save the files created.
+  * **package.json** lets GitHub load other packages it needs to run the tests.
+  * **.gitignore** is for developers who want to work in their local environment.
+  * **.env-example** can help guide developers who want to work in their local environment to set up the environment variables.
 ---
 template: secrets_list
 content: |
@@ -499,7 +460,7 @@ review:
       * **Package name**:[BR]
       ${ installer.package_name }
       
-      The new branch will be named ${ installer.branch_name }
+      The new branch will be named **${ installer.branch_name }**.
   - note: |
       ---
       There may be a few more steps after this to finish up. Continue when you are ready.
@@ -620,6 +581,14 @@ content: |
   `https://dev.court-wizards.org/interview?i=docassemble.playground222ProjectName%3Asome_file.yml` [BR]
   If you are sure you have the whole URL of a running interview, please [file an issue](https://github.com/plocket/docassemble-ALAutomatedTestingTests) and include your interview URL in the report.
 ---
+depends on: github_token_error
+code: |
+  installer.github_token_error = github_token_error.content
+---
+template: github_token_error
+content: |
+  GitHub cannot find that [personal access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token). You can try copying and pasting it again or you can try [making a new one](https://github.com/settings/tokens).
+---
 depends on: github_pat_scopes_error
 code: |
   installer.github_pat_scopes_error = github_pat_scopes_error.content
@@ -627,14 +596,6 @@ code: |
 template: github_pat_scopes_error
 content: |
   What you are trying to do needs ${ token_permissions_scope } scope(s). The permission scope(s) of the [Github personal access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) ending in \*\*\*${ installer.token[-4:] } are **${ comma_and_list( installer.github.oauth_scopes ) }**. You can try copying and pasting the token again or you can try [making a new one](https://github.com/settings/tokens). (This disobeys plain language guidelines, sorry)
----
-depends on: github_token_error
-code: |
-  installer.github_token_error = github_token_error.content
----
-template: github_token_error
-content: |
-  The permission scope of that [Github personal access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) are not sufficient. Are you sure it has ${ token_permissions_scope } scope permissions? You can try copying and pasting it again or you can try [making a new one](https://github.com/settings/tokens).
 ---
 depends on: github_url_error
 code: |
@@ -647,6 +608,26 @@ content: |
   `https://github.com/owner_name/repo_name`
   
   If you are sure you have the correct GitHub URL, please [file an issue](https://github.com/plocket/docassemble-ALAutomatedTestingTests) and include the GitHub URL.
+---
+depends on: github_repo_not_found_error
+code: |
+  installer.github_repo_not_found_error = github_repo_not_found_error.content
+---
+template: github_repo_not_found_error
+content: |
+  GitHub cannot find the **${ installer.repo_name }** repository owned by the owner **${ installer.owner_name }**. Example of a valid URL:
+  
+  `https://github.com/owner_name/repo_name`
+  
+  You gave the repository address of **${ installer.repo_url }**. Are you sure that is correct?
+---
+depends on: not_collaborator_error
+code: |
+  installer.not_collaborator_error = not_collaborator_error.content
+---
+template: not_collaborator_error
+content: |
+  The user **${ installer.user_name }** does not have collaborator access to change the files in the **${ installer.repo_name }** repository owned by the owner **${ installer.owner_name }**. You can ask the admin to give correct access.
 ---
 depends on: org_does_not_exist_error
 code: |
@@ -662,35 +643,15 @@ code: |
 ---
 template: not_an_org_member_error
 content: |
-  **${ installer.user_name }** might not be a member of **${ installer.owner_name }**. Try double checking the names.
+  **${ installer.user_name }** might not be a **member** of **${ installer.owner_name }**. Try double checking the names.
 ---
-depends on: not_repo_admin_error
+depends on: not_org_admin_error
 code: |
-  installer.not_repo_admin_error = not_repo_admin_error.content
+  installer.not_org_admin_error = not_org_admin_error.content
 ---
-template: not_repo_admin_error
+template: not_org_admin_error
 content: |
-  **${ installer.user_name }** might not be an admin of **${ installer.repo_url }**. Try double checking the names.
----
-depends on: github_repo_not_found_error
-code: |
-  installer.github_repo_not_found_error = github_repo_not_found_error.content
----
-template: github_repo_not_found_error
-content: |
-  GitHub cannot find the **${ installer.repo_name }** repository owned by the owner **${ installer.owner_name }**. Example of a valid URL:
-  
-  `https://github.com/owner_name/repo_name`
-  
-  You gave the repository address of **${ installer.repo_url }**. Are you sure that is correct?
----
-depends on: github_access_error
-code: |
-  installer.github_access_error = github_access_error.content
----
-template: github_access_error
-content: |
-  The user **${ installer.user_name }** does not have collaborator access to change the files in the **${ installer.repo_name }** repository owned by the owner **${ installer.owner_name }**. You can ask the admin to give correct access.
+  **${ installer.user_name }** might not be an **admin** of the organization **${ installer.owner_name }**. Try double checking the names.
 ---
 depends on: github_branch_name_error
 code: |
@@ -699,7 +660,3 @@ code: |
 template: github_branch_name_error
 content: |
   It looks like all the allowed branch names are taken. To solve this, delete some of the branches that start with "${ installer.default_branch_name }".
----
-include:
-  - temp.yml
----

--- a/docassemble/ALAutomatedTestingTests/data/questions/al_set_up_testing.yml
+++ b/docassemble/ALAutomatedTestingTests/data/questions/al_set_up_testing.yml
@@ -14,6 +14,8 @@ modules:
 ---
 objects:
   - installer: TestInstaller
+  # TODO: see if this can work instead of other shinannigans
+  #- has_secrets: DADict  #.using(there_are_any=False)
 ---
 include:
   - al_testing_files_to_push.yml
@@ -55,12 +57,13 @@ code: |
     # Otherwise carry on
     get_secrets_info
   
-  ## Get github token. Different wording for contributor vs. admin
-  #installer.token
+  # Get github token. Different wording for different goals
+  installer.token
   #set_github_auth
   #
   ## If setting up test files, get repo address
   
+  # TODO: next steps for secrets - ensure the secret has the access settings you want
   
   ##
   ##
@@ -81,7 +84,7 @@ code: |
       log_into_test_account
       
   installer.password
-  set_da_info
+  #set_da_info
       
   get_secrets_info = True
 ---
@@ -148,13 +151,15 @@ id: admin goal
 question: |
   What do you want to do?
 subquestion: |
-  For tests to run, they need to be able to make a Project on your docassemble server and then run an interview from that Project. [GitHub secrets](https://docs.github.com/en/actions/reference/encrypted-secrets) store and encrypt the information the tests need in order to do that. You can use this tool to set these secrets:
+  For tests to run, they need to be able to make a Project on your docassemble server and then run an interview from that Project. [GitHub secrets](https://docs.github.com/en/actions/reference/encrypted-secrets) store and encrypt the information the tests need in order to do that. This interview will help you set these secrets:
   
   ${ secrets_list }
   
-  If an admin sets up organization secrets they are availalble for all organization repositories and you don't need repository secrets.
+  Once an organization admin sets up secrets, repository secrets will be unnecessary and any developer that can push to a repository can set up automated tests for it with no other special permissions.
   
   ${ how_to_see_repo_secrets }
+  
+  ${ check_secrets_access }
   
   What do you want to do?
 fields:
@@ -192,20 +197,26 @@ fields:
     js show if: |
       val('wants_to_set_up_tests') && !val('wants_to_set_repo_secrets') && !val('wants_to_set_org_secrets')
 validation code: |
+  # Define undefined values
+  # Considered bad practice generally, but currently seems more maintainable
+  # If it becomes less maintainable, we can move this elsewhere
+  if not defined('wants_to_set_org_secrets'):
+    wants_to_set_org_secrets = False
+  if not defined('wants_to_set_repo_secrets'):
+    wants_to_set_repo_secrets = False
+  if not defined('has_secrets'):
+    has_secrets = DADict('has_secrets', there_are_any=False)  # None are true
+    
+  # Validate
   if (wants_to_set_up_tests
-      and (not defined('wants_to_set_org_secrets')
-        or not wants_to_set_org_secrets)
-      and (not defined('wants_to_set_repo_secrets')
-        or not wants_to_set_repo_secrets)
+      and not wants_to_set_org_secrets
+      and not wants_to_set_repo_secrets
       and not has_secrets.any_true()):
     validation_error("If you want to set up tests and the package does not have access to secrets, you must choose a way to set secrets.")
   if (not wants_to_set_up_tests
-      and (not defined('wants_to_set_org_secrets')
-        or not wants_to_set_org_secrets)
-      and (not defined('wants_to_set_repo_secrets')
-        or not wants_to_set_repo_secrets)):
+      and not wants_to_set_org_secrets
+      and not wants_to_set_repo_secrets):
     validation_error("You must mark at least one choice.")
-  # Make sure has_secrets is defined in this validation code?
 ---
 id: which secrets exist non-admin
 question: |
@@ -298,60 +309,59 @@ auto terms:
   - the URL in the address bar: |
       The interview URL will give us the account's Playground ID and the address of the server that the account is on.
 ---
-id: org github auth
-#if: installer.goal == 'org_secrets' and permissions_status == 'admin'
-continue button field: get_org_secrets_info
-question: |
-  Setting up GitHub secrets
-subquestion: |
-  [Organization-wide secrets](https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-an-organization) will allow any of your contributors to very easily add automated testing to any of your organization's packages. If they can push to the repository, they can set up testing for it.
-
-  :clock: Setting up secrets could take about 20 minutes
-  
-  ---
-  
-  You will set these secrets:
-  
-  ${ secrets_list }
-  
-  ---
-  
-  1. Start making a [personal access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) for your GitHub account. You will be able to delete it after you are finished here.
-  1. Tap the checkbox for "admin:org" permissions.
-  1. Finish creating the token.
-  1. Copy the token and paste it below.
-fields:
-  - Personal access token: installer.token
-    datatype: password
-    help: |
-      The token must have "admin:org" permissions.
-  - note: |
-      We also need the GitHub organizatoin name with correct capitalization. Example:[BR]
-      `SuffolkLITLab`
-  - Organization: installer.owner_name
----
-# TODO: Add instructions on how to find the GitHub repo url on Packages page (maybe point to docs)
 id: github auth
 question: |
-  GitHub authorization
+  Authorizing for GitHub
 subquestion: |
-  You must be an admin on the GitHub repository so you can temporarily give this form permission to add files and set "SECRETS". Once you are logged in as an admin:
+  You now need to create temporary authorization for GitHub using a [personal access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token).
   
-  1. Start making a [personal access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) for your GitHub account.
-  1. Tap the checkbox for 'workflow' permissions. That should also trigger 'repo' permissions. This form needs both.
+  1. Start making a [personal access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token). You will be able to delete it after you are finished here.
+  % if wants_to_set_org_secrets:
+  1. Tap the checkbox for "admin:org" permissions.
+  % elif wants_to_set_repo_secrets:
+  1. Tap the checkbox for "workflow" permissions. That should also trigger "repo" permissions.
+  % else:
+  1. Tap the checkbox for "repo" permissions.
+  % endif
   1. Finish creating the token.
   1. Copy the token and paste it below.
 fields:
   - Personal access token: installer.token
     datatype: password
     help: |
-      The token must have 'repo' and 'workflow' permissions.
+      The token must have ${ token_permissions_level } permissions.
   - note: |
       We also need the GitHub repository URL of the package. Example:[BR]
-      `https://github.com/LawMagic/docassemble-GreatForm`
-  - GitHub URL: installer.repo_url
+      `https://github.com/TheLawFantastic/docassemble-GreatForm`
+    show if:
+      code: |
+        wants_to_set_up_tests or wants_to_set_repo_secrets
+  - Repo URL: installer.repo_url
     help: |
       The repository's URL will give us the name of the repo and its owner.
+    show if:
+      code: |
+        wants_to_set_up_tests or wants_to_set_repo_secrets
+  - note: |
+      We also need the name of the GitHub organization. Example:[BR]
+      `SuffolkLITLab`
+    show if:
+      code: |
+        not wants_to_set_up_tests and wants_to_set_org_secrets
+  - Organization name: installer.owner_name
+    show if:
+      code: |
+        not wants_to_set_up_tests and wants_to_set_org_secrets
+---
+template: token_permissions_level
+content: |
+  % if wants_to_set_org_secrets:
+  "admin:org"
+  % elif wants_to_set_repo_secrets:
+  "workflow"
+  % else:
+  "repo"
+  % endif
 ---
 ## TODO: Add link to docs where we explain how the library makes a project, etc.
 ## TODO: Add links to the actual github repo and files and folders

--- a/docassemble/ALAutomatedTestingTests/data/questions/al_set_up_testing.yml
+++ b/docassemble/ALAutomatedTestingTests/data/questions/al_set_up_testing.yml
@@ -139,17 +139,17 @@ fields:
   - I am an admin of the GitHub organization with access to security settings: is_org_admin
     datatype: yesnowide
     default: false
-  - I am a contributor of the GitHub organization WITHOUT access to security settings: is_org_contributor
+  - I am a collaborator of the GitHub organization WITHOUT access to security settings: is_org_collaborator
     datatype: yesnowide
   - I am an admin of the package's GitHub repository with access to security settings: is_repo_admin
     datatype: yesnowide
-  - I am a contributor to the package's GitHub repository WITHOUT access to security settings: is_repo_contributor
+  - I am a collaborator to the package's GitHub repository WITHOUT access to security settings: is_repo_collaborator
     datatype: yesnowide
 validation code: |
   if (not is_org_admin
-      and not is_org_contributor
+      and not is_org_collaborator
       and not is_repo_admin
-      and not is_repo_contributor):
+      and not is_repo_collaborator):
     validation_error("You cannot set up tests if you don't have at least one of these roles.")
 ---
 id: admin goal
@@ -321,11 +321,12 @@ subquestion: |
   You now need to create temporary authorization for GitHub using a [personal access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token).
   
   1. Start making a [personal access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token). You will be able to delete it after you are finished here.
-  % if wants_to_set_org_secrets:
+  % elif wants_to_set_org_secrets:
   1. Tap the checkbox for "admin:org" permissions.
   % elif wants_to_set_repo_secrets:
   1. Tap the checkbox for "workflow" permissions. That should also trigger "repo" permissions.
-  % else:
+  % endif
+  % if wants_to_set_up_tests and not wants_to_set_repo_secrets:
   1. Tap the checkbox for "repo" permissions.
   % endif
   1. Finish creating the token.
@@ -360,7 +361,9 @@ fields:
 ---
 template: token_permissions_level
 content: |
-  % if wants_to_set_org_secrets:
+  % if wants_to_set_up_tests and wants_to_set_org_secrets:
+  "admin:org" and "repo"
+  % elif wants_to_set_org_secrets:
   "admin:org"
   % elif wants_to_set_repo_secrets:
   "workflow"
@@ -537,7 +540,7 @@ question: |
 subquestion: |
   [Check that you have set up the secrets for your organization](https://github.com/organizations/${ installer.owner_name }/settings/secrets/actions)
   
-  You should be finished. Your contributors can now use this interview to set up testing for their repositories without the need for special permissions.
+  You should be finished. Your collaborators can now use this interview to set up testing for their repositories without the need for special permissions.
 buttons:
   - Restart: restart
 ---

--- a/docassemble/ALAutomatedTestingTests/data/questions/al_set_up_testing.yml
+++ b/docassemble/ALAutomatedTestingTests/data/questions/al_set_up_testing.yml
@@ -39,6 +39,8 @@ code: |
   if len( installer.errors ) > 0:
     show_errors
   
+  installer.token = "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"
+  installer.owner_name = "alsjdflaskjdfiwfn"
   # Secrets
   if is_org_admin or is_repo_admin:
     wants_to_set_up_tests
@@ -70,8 +72,8 @@ code: |
   ### confirm
   ##is_ready
   ##
-  ### update github
-  ##update_github
+  # update github
+  update_github
   ##
   ###instructions
   ##force_ask( 'next_steps' )
@@ -101,16 +103,19 @@ code: |
   set_org_secrets = True
 ---
 code: |
-  # These vars need to be defined before creating a branch.
-  # Otherwise, because of da execution behavior, they cause
-  # loops that end up creating 5 branches. It seemed to make
-  # sense to put them in here.
-  installer.env_example_str = installer.env_example.content
-  installer.example_test_str = installer.example_test.content
-  installer.gitignore_str = installer.gitignore.content
-  installer.package_json_str = installer.package_json.content
-  installer.run_form_tests_str = installer.run_form_tests.content
-  installer.update_github()
+  if 'wants_to_set_org_secrets' or 'wants_to_set_repo_secrets':
+    installer.create_secrets()
+  if False:
+    # These vars need to be defined before creating a branch.
+    # Otherwise, because of da execution behavior, they cause
+    # loops that end up creating 5 branches. It seemed to make
+    # sense to put them in here.
+    installer.env_example_str = installer.env_example.content
+    installer.example_test_str = installer.example_test.content
+    installer.gitignore_str = installer.gitignore.content
+    installer.package_json_str = installer.package_json.content
+    installer.run_form_tests_str = installer.run_form_tests.content
+    installer.update_github()
   update_github = True
 ---
 auto terms:

--- a/docassemble/ALAutomatedTestingTests/data/questions/al_set_up_testing.yml
+++ b/docassemble/ALAutomatedTestingTests/data/questions/al_set_up_testing.yml
@@ -18,7 +18,15 @@ objects:
 include:
   - al_testing_files_to_push.yml
 ---
-# I've done this once before. Trust me...
+comment: |
+  want to set org secrets
+    must be an org admin
+  want to set up tests for one package
+    have secrets
+      set up url
+    don't have secrets
+      need to be an admin and set up repo secrets
+---
 mandatory: True
 code: |
   ## for dev
@@ -29,28 +37,144 @@ code: |
   if len( installer.errors ) > 0:
     show_errors
   
-  intro
+  # Secrets
+  if is_org_admin or is_repo_admin:
+    wants_to_set_up_tests
+    if not defined('has_secrets'):
+      has_secrets = False
+  else:
+    wants_to_set_org_secrets = False
+    wants_to_set_repo_secrets = False
+    wants_to_set_up_tests = True
+    # DO NOT define has_secrets
+  
+  if not has_secrets:
+    # Get secrets, org or repo
+    pass
+  
+  # Get file pushing permission. may need to set up token
+  # If setting up files, get repo address
+  
+  #if wants_to_set_up_tests and not wants_to_set_org_secrets and not wants_to_set_repo_secrets:
+  #
+  #
+  #if wants_to_set_up_tests:
+  #  # do secrets exist already?
+  #  # admins will have been asked this already
+  #  has_secrets
+  #
+  #if wants_to_set_up_tests:
+  #  if not has_secrets:
+  #    #must have secrets to set up tests kickout
+  #    pass
+  #
+  #if wants_to_set_org_secrets:
+  #  #set_org_secrets
+  #  
+  #
+  #  if not wants_to_set_org_secrets and not wants_to_set_repo_secrets:
+  #    if not existing_secrets['org'] and not existing_secrets['repo']:
+  #    if is_org_admin:
+  #      #set_org_secrets
+  #      pass
+  #    
+  #    elif is_repo_admin:
+  #      #set_repo_secrets
+  #      pass
+  #      
+  #    else:
+  #      pass
+  #      
+  #
+  #
+  #if is_org_admin:
+  #  if wants_to_set_org_secrets:
+  #    #set_org_secrets
+  #    pass
+  #  elif wants_to_set_repo_secrets:
+  #    #set_repo_secrets
+  #    pass
+  #elif is_repo_admin:
+  #  if wants_to_set_repo_secrets:
+  #    #set_repo_secrets
+  #    pass
+  #elif is_org_contributor or is_repo_contributor:
+  #  if not existing_secrets['org'] and not existing_secrets['repo']:
+  #    #no_secrets_kickout
+  #    pass
+  #
+  #
+  #if  not has_set_secrets && wants_to_set_up_tests:
+  #  pass
+  #
+  ## The tricky one is the admin who wants to set up tests, but not secrets
+  ## If admin and want to set up tests, but not want to set up secrets, ask if already has secrets (existing_secrets)
+  ## if not, set secrets
+  #
+  ##permissions_status
+  ##'contributor'
+  ##'admin'
+  ##if installer.goal == 'org_secrets':
+  ##  if permissions_status == 'admin':
+  ##    get_org_secrets_info
+  ##    set_org_secrets
+  ##  if permissions_status == 'contributor':
+  ##    need_to_be_an_org_admin
+  ##if installer.goal == 'one_package':
+  ##  if permissions_status == 'contributor':
+  ##    if part_of_an_org and (org_has_secrets_already or wants_only_repo_secrets):
+  ##      pass
+  ##    else:
+  ##      need_to_be_a_repo_admin
+  ##  # Not kicked out so far
+  ##  repo_intro
+  #
+  #if will_test_on_this_server:
+  #  if not logged_into_test_account_on_interview_server:
+  #    log_into_test_account
+  ##
+  ### da stuff
+  ##installer.password
+  ##set_da_info
+  ##
+  ### github stuff
+  ##installer.token
+  ##set_github_auth
+  ##
+  ### confirm
+  ##is_ready
+  ##
+  ### update github
+  ##update_github
+  ##
+  ###instructions
+  ##force_ask( 'next_steps' )
+  
+  force_ask( 'next_steps_org' )
+---
+code: |
   
   if will_test_on_this_server:
     if not logged_into_test_account_on_interview_server:
       log_into_test_account
-  
-  # da stuff
+      
   installer.password
   set_da_info
-  
-  # github stuff
-  installer.token
-  set_github_auth
-  
-  # confirm
-  is_ready
-  
-  # update github
-  update_github
-  
-  #instructions
-  force_ask( 'next_steps' )
+      
+  handle_set_secrets = True
+---
+code: |
+  if wants_to_set_repo_secrets:
+    #set_repo_secrets
+    pass
+  handle_repo_secrets = True
+---
+code: |
+  handle_has_secrets = True
+---
+code: |
+  installer.set_org_secrets()
+  set_org_secrets = True
 ---
 code: |
   installer.set_da_info()
@@ -76,12 +200,227 @@ code: |
 auto terms:
   - the docassemble account where the tests will run: Remember that **you can use your own account** and you can always change this later.
 ---
+comment: |
+  https://flowchart.fun/c#H4hQBsEME8HsFcAuAuUACNA7SBbApsmgCaQDmATnumuZJgNYAiAluYQDIBKoIwooAegBUAFQAWzAM5pIAB1loA7rHL1pAI2hpE0Wc0ylqASUxE8mRPtJoAxpUiI80yGnD7622NrF5b8cpQWrvpUGHRajgAeKGjqeABmKr4uNrDgsJi29o7OrpBx4NQYsIg+bGgAFDbwkoiwOGhGjACU1ADC2cnBDMSseDaI4Fo1Vt6+eJGQA3kF2hOIRcH0vqVShBXiUjLySipqsRG6Vq0YGADa1bX1jYwAumgqixiaMkREo3RoZ033dEQ0CTwgRso1KDiepzcy28a0qlzqDSazTQAgEaAAmghbJ9IOBJF4ar5JFZwHgALRuTC+VI4fAWSSgIQCQRCUCPHDwcCWSlUGl0xAM0AACUgADdfPF4JgAIRoQA8G4BI-cZzLZ5GskCIOH01BsdEIkjwiAearQBrshoZ50osi8knuusw+sNAJtpv6lAF1DOOQF9r1bqN8AUPrQ8WYpIZ1q8Gq1mB1-oqUdNJ2xjsqPskrRU1lSFnIzHUSEeGCqGUQ+fUrSTufLBaL5GopbzBdaFzLFfusJrFfr1GzaDEkGkZo9ltOFQzKaTg+H7otiwnTgFKcwtrnntOWC8GdAQA
+---
+id: repo role
+question: |
+  Document Assembly Line automated integrated testing
+subquestion: |
+  This tool helps developers or organizations set up automated integrated testing for docassemble packages that have a GitHub repository.
+  
+  What you can do depends on your situation and what kind of GitHub permissions you have.
+  
+  Which descriptions fit you? Pick at least one.
+fields:
+  - I am an admin of the GitHub organization with access to security settings: is_org_admin
+    datatype: yesnowide
+    default: false
+  - I am a contributor of the GitHub organization WITHOUT access to security settings: is_org_contributor
+    datatype: yesnowide
+  - I am an admin of the package's GitHub repository with access to security settings: is_repo_admin
+    datatype: yesnowide
+  - I am a contributor to the package's GitHub repository WITHOUT access to security settings: is_repo_contributor
+    datatype: yesnowide
+validation code: |
+  if (not is_org_admin
+      and not is_org_contributor
+      and not is_repo_admin
+      and not is_repo_contributor):
+    validation_error("You cannot set up tests if you don't have at least one of these roles.")
+---
+id: admin goal
+question: |
+  What do you want to do?
+subquestion: |
+  These tests need to make a Project on your docassemble server and then run an interview from that Project. [GitHub secrets](https://docs.github.com/en/actions/reference/encrypted-secrets) store and encrypt the information the tests need in order to do that. The tests need these secrets:
+  
+  ${ secrets_list }
+  
+  If an admin sets up organization secrets they are availalble for all organization repositories and you don't need repository secrets.
+  
+  ${ how_to_see_repo_secrets }
+  
+  What do you want to do?
+fields:
+  - I want to set or update the organization's secrets: wants_to_set_org_secrets
+    datatype: yesnowide
+    js enable if: |
+      !val('wants_to_set_repo_secrets')
+    show if:
+      code: |
+        is_org_admin
+  - I want to set or update the repository's secrets: wants_to_set_repo_secrets
+    datatype: yesnowide
+    show if:
+      code: |
+        is_org_admin
+    js enable if: |
+      !val('wants_to_set_org_secrets')
+  - I want to set or update the repository's secrets: wants_to_set_repo_secrets
+    datatype: yesnowide
+    show if:
+      code: |
+        not is_org_admin
+  - I want to set up testing for a package: wants_to_set_up_tests
+    datatype: yesnowide
+  - note: A package must have access to GitHub secrets in order to run tests.
+    js show if: |
+      val('wants_to_set_up_tests') && !val('wants_to_set_repo_secrets') && !val('wants_to_set_org_secrets')
+  - The package already has access to organization or repository secrets: has_secrets
+    datatype: yesnowide
+    help: |
+      ${ how_to_see_repo_secrets } (see above for link)
+    js show if: |
+      val('wants_to_set_up_tests') && !val('wants_to_set_repo_secrets') && !val('wants_to_set_org_secrets')
+validation code: |
+  if (wants_to_set_up_tests
+      and not wants_to_set_repo_secrets
+      and not wants_to_set_org_secrets
+      and not has_secrets):
+    validation_error("If you want to set up tests and the package does not have access to secrets, you must choose a way to set secrets.")
+  if (not wants_to_set_up_tests
+      and not wants_to_set_org_secrets
+      and not wants_to_set_repo_secrets):
+    validation_error("You must mark at least one choice.")
+  # Make sure has_secrets is defined with this validation code?
+---
+# If non-admin and want to set up testing
+id: which secrets exist non-admin
+question: |
+  GitHub secrets
+subquestion: |
+  For tests to work, a repository needs [GitHub secrets](https://docs.github.com/en/actions/reference/encrypted-secrets) set by the organization or repo admin. What is the status of the secrets now? If you don't know, ask the admin of the organization or repository if these secrets are set:
+
+  ${ secrets_list }
+  
+  ${ how_to_see_repo_secrets }
+fields:
+  - Does the package have access to those secrets?: has_secrets
+    datatype: radio
+    choices:
+      - The package has access to those secrets: True
+      - The repository has those secrets: repo
+---
+template: how_to_see_repo_secrets
+content: |
+  To see a repository's secrets, an admin can go to the same place as where they [set the repository's secrets](https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository).
+---
+  #- What are you setting up this time?: installer.goal
+  #  datatype: radio
+  #  choices:
+  #    - I'm setting up organization [GitHub secrets](https://docs.github.com/en/actions/reference/encrypted-secrets): org_secrets
+  #    - I'm setting up testing for one package: one_package
+  #    #- I'm setting up testing for multiple packages: multiple_packages
+  #- What kind of GitHub permissions do you have for this?: permissions_status
+  #  datatype: radio
+  #  choices:
+  #    - I am a contributor, but I do not have access to security settings: contributor
+  #    - I am an admin and have access to security settings: admin
+---
+#if: installer.goal == 'one_package' and
+event: nothing
+question: |
+  thing
+subquestion: |
+  
+  - How do you want to set up testing?: repo_scope
+    datatype: radio
+    enabled if:
+      variable: installer.goal
+      is: one_package
+    choices:
+      - As part of an organization: org
+      - Independent of an organization: independent
+  - 
+    datatype: yesno
+  
+    datatype: yesno
+    disable if:
+      variable: installer.goal
+      is: one_package
+  - note: |
+      Ask an admin in the GitHub organization if the organization already has these secrets:
+      
+      ${ secrets_list }
+      
+    show if: part_of_an_org
+  - This organization already has the necessary secrets: org_has_secrets_already
+    datatype: yesno
+    show if: org_package
+  #- Does the docassemble package or packages belong to an organization?: is_org_package
+  #  datatype: yesnomayberadio
+  #- Which of these best describes you?: type_of_org_user
+  #  show if:
+  #    variable: is_org_package
+  #    is: True
+  #  datatype: radio
+  #  choices:
+  #    - I am a GitHub contributor, but I have no access to security settings
+  #    - I am a GitHub contributor for a GitHub organization's packages, but I have no access to security settings for this package's repository: org_dev
+  #    - I am a GitHub contributor for one package's repository, but I have no access to security settings: repo_dev
+  #    - I am an admin for this package's repository and can access security settings: repo_admin
+  #    - I am an admin of this package's organization: org_admin
+---
+id: org secrets
+#if: installer.goal == 'org_secrets' and permissions_status == 'admin'
+continue button field: get_org_secrets_info
+question: |
+  Setting up GitHub secrets for your organization
+subquestion: |
+  [Organization-wide secrets](https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-an-organization) will allow any of your contributors to very easily add automated testing to any of your organization's packages. If they can push to the repository, they can set up testing for it.
+
+  :clock: This could take about 10 minutes
+  
+  ---
+  
+  You will set these secrets:
+  
+  ${ secrets_list }
+  
+  ---
+  
+  You must be an admin on the GitHub organization so you can temporarily give this tool permission to create secrets. Once you are logged into GitHub as an admin:
+  
+  1. Start making a [personal access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) for your GitHub account. You will be able to delete it after you are finished here.
+  1. Tap the checkbox for "admin:org" permissions.
+  1. Finish creating the token.
+  1. Copy the token and paste it below.
+fields:
+  - Personal access token: installer.token
+    datatype: password
+    help: |
+      The token must have "admin:org" permissions.
+  - note: |
+      We also need the GitHub organizatoin name with correct capitalization. Example:[BR]
+      `SuffolkLITLab`
+  - Organization: installer.owner_name
+---
+id: not org admin kickout
+event: need_to_be_an_org_admin
+question: |
+  You need to be an admin
+subquestion: |
+  You need to be an organization admin to set up organization secrets. Contact your admin and give them a link to this interview so they can set up the organization secrets.
+---
+id: non admin repo questions
+question: |
+  Where will your secrets be?
+  part_of_an_org and (org_has_secrets_already or wants_only_repo_secrets)
+---
+id: non admin repo kickout
+event: need_to_be_a_repo_admin
+question: |
+  You need to be an admin
+subquestion: |
+  You need to be an admin on a repository to set up automated tests. Contact your admin and give them a link to this interview so they can set up automated testing for this package.
+---
 # TODO: Add link to docs where we explain how the library makes a project, etc.
 # TODO: Add links to the actual github repo and files and folders
 # TODO: only show 'other than you' if the person is logged in
-id: intro
+id: intro personal repo
 question: |
-  Set up AL automated integrated testing
+  Set up Document Assembly Line automated integrated testing
 subquestion: |
   This interview will help you set up automated integrated GitHub testing for a docassemble package.
 
@@ -111,7 +450,7 @@ subquestion: |
   
   Your answers will be encrypted end-to-end and on the server. No one other than you will have access to them.
   
-continue button field: intro
+continue button field: repo_intro
 ---
 template: files_list
 content: |
@@ -156,28 +495,45 @@ subquestion: |
 
 continue button field: log_into_test_account
 ---
+id: org secrets info
+question: |
+  Docassemble
+subquestion: |
+  Tests will create Projects in an account on your docassemble server, pull in the GitHub code, and run the interviews.
+  
+  Decide on the docassemble account where the tests will run. Answer the questions below for the account. If you want to use your own account, put your own docassemble email and password below.
+fields:
+  - Account email: installer.email
+    datatype: email
+  - Account password: installer.password
+    datatype: password
+  - note: |
+      What is the address of your docassemble server? Example:[BR]
+      `https://dev.legal-help.org`
+  - no label: installer.server_url
+auto terms:
+  - the URL in the address bar: |
+      The interview URL will give us the account's Playground ID and the address of the server that the account is on.
+---
 id: server info
 question: |
   Docassemble
 subquestion: |
-  These tests will create Projects in an account on your docassemble server, pull in the GitHub code, and run the interviews.
+  These tests will create Projects in an account on your docassemble server, pull in the GitHub code, and run the interviews. To do that, they need docassemble login information. This is what will be in the encrypted GitHub secrets.
   
-  Next:
-  
-  1. Decide on the docassemble account where the tests will run.
+  1. Decide on the docassemble account where the tests will run
   1. Make sure you are logged into that account.
-  1. [Make a new Project and pull in GitHub code for the package](https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/github#get-github-code-into-your-playground). The Project name does not matter.
+  1. Answer the questions below for the docassemble account that will run tests. If you want to use your own account, put your own docassemble email and password below.
   
-  Answer the questions below for the account. If you want to use your own account, put your own docassemble email and password below.
 fields:
   - Email: installer.email
     datatype: email
   - Password: installer.password
     datatype: password
   - note: |
-      In the Playground, open the YAML file for which you want automated tests. Run it. What is the URL in the address bar? Example:[BR]
-      `https://dev.legal.org/interview?i=docassemble.playground22ProjectName%3Asome_file.yml`
-  - Interview URL: installer.playground_url
+      Go to the Playground of the account and run any working YAML file. For example, test.yml. What is the URL in the address bar? Example:[BR]
+      `https://dev.legal.org/interview?i=docassemble.playground22%3Atest.yml`
+  - URL: installer.playground_url
 auto terms:
   - the URL in the address bar: |
       The interview URL will give us the account's Playground ID and the address of the server that the account is on.    
@@ -254,8 +610,6 @@ review:
 continue button field: is_ready
 continue button label: Finish
 ---
-
----
 event: next_steps
 prevent going back: True
 question: |
@@ -317,6 +671,16 @@ comment: |
   TODO: Should we offer to delete their personal access token for them in the interview itself? Do we have enough permissions?
   TODO: Implement feedback form instead of linking issues. See AL core for that coming soon.
   TODO: Add link to documentation on writing tests.
+---
+event: next_steps_org
+question: |
+  Next steps
+subquestion: |
+  [Check that you have set up the secrets for your organization](https://github.com/organizations/${ installer.owner_name }/settings/secrets/actions)
+  
+  You should be finished. Your contributors can now use this interview to set up testing for their repositories without the need for special permissions.
+buttons:
+  - Restart: restart
 ---
 id: show_errors
 event: show_errors

--- a/docassemble/ALAutomatedTestingTests/data/questions/al_set_up_testing.yml
+++ b/docassemble/ALAutomatedTestingTests/data/questions/al_set_up_testing.yml
@@ -315,6 +315,7 @@ auto terms:
       The interview URL will give us the account's Playground ID and the address of the server that the account is on.
 ---
 # TODO: Can an org admin sometimes not have push access to an org repo?
+# TODO: Will org admins try to also add tests to a non-org repo?
 id: github auth
 question: |
   Authorizing for GitHub
@@ -637,4 +638,7 @@ code: |
 template: github_branch_name_error
 content: |
   It looks like all the allowed branch names are taken. To solve this, delete some of the branches that start with "${ installer.default_branch_name }".
+---
+include:
+  - temp.yml
 ---

--- a/docassemble/ALAutomatedTestingTests/data/questions/al_set_up_testing.yml
+++ b/docassemble/ALAutomatedTestingTests/data/questions/al_set_up_testing.yml
@@ -632,6 +632,3 @@ template: github_branch_name_error
 content: |
   It looks like all the allowed branch names are taken. To solve this, delete some of the branches that start with "${ installer.default_branch_name }".
 ---
-include:
-  - temp.yml
----

--- a/docassemble/ALAutomatedTestingTests/data/questions/al_set_up_testing.yml
+++ b/docassemble/ALAutomatedTestingTests/data/questions/al_set_up_testing.yml
@@ -587,7 +587,15 @@ code: |
 ---
 template: not_collaborator_error
 content: |
-  The user **${ installer.user_name }** does not have collaborator access to change the files in the **${ installer.repo_name }** repository owned by the owner **${ installer.owner_name }**. You can ask the admin to give correct access.
+  The user **${ installer.user_name }** is not a collaborator in the **${ installer.repo_name }** repository owned by the owner **${ installer.owner_name }**. You can ask the admin to give correct access.
+---
+depends on: permissions_error
+code: |
+  installer.permissions_error = permissions_error.content
+---
+template: permissions_error
+content: |
+  The user **${ installer.user_name }** has **${ installer.permissions }** permissions for the **${ installer.repo_name }** repository, but needs **write**, **maintain**, or **admin** permissions. You can ask the admin to give you correct access. **${ installer.owner_name }** is the owner.
 ---
 depends on: org_does_not_exist_error
 code: |

--- a/docassemble/ALAutomatedTestingTests/data/questions/al_set_up_testing.yml
+++ b/docassemble/ALAutomatedTestingTests/data/questions/al_set_up_testing.yml
@@ -49,8 +49,7 @@ code: |
     # DO NOT define has_secrets
   
   if not has_secrets:
-    # Get secrets, org or repo
-    pass
+    get_secrets
   
   # Get file pushing permission. may need to set up token
   # If setting up files, get repo address
@@ -88,15 +87,15 @@ code: |
   installer.password
   set_da_info
       
-  handle_set_secrets = True
----
-code: |
-  installer.set_org_secrets()
-  set_org_secrets = True
+  get_secrets = True
 ---
 code: |
   installer.set_da_info()
   set_da_info = True
+---
+code: |
+  installer.set_org_secrets()
+  set_org_secrets = True
 ---
 code: |
   installer.set_github_auth()
@@ -193,36 +192,48 @@ fields:
       val('wants_to_set_up_tests') && !val('wants_to_set_repo_secrets') && !val('wants_to_set_org_secrets')
 validation code: |
   if (wants_to_set_up_tests
-      and not wants_to_set_repo_secrets
-      and not wants_to_set_org_secrets
+      and (not defined('wants_to_set_org_secrets')
+        or not wants_to_set_org_secrets)
+      and (not defined('wants_to_set_repo_secrets')
+        or not wants_to_set_repo_secrets)
       and not has_secrets):
     validation_error("If you want to set up tests and the package does not have access to secrets, you must choose a way to set secrets.")
   if (not wants_to_set_up_tests
-      and not wants_to_set_org_secrets
-      and not wants_to_set_repo_secrets):
+      and (not defined('wants_to_set_org_secrets')
+        or not wants_to_set_org_secrets)
+      and (not defined('wants_to_set_repo_secrets')
+        or not wants_to_set_repo_secrets)):
     validation_error("You must mark at least one choice.")
-  # Make sure has_secrets is defined with this validation code?
+  # Make sure has_secrets is defined in this validation code?
 ---
 # If non-admin and want to set up testing
 id: which secrets exist non-admin
 question: |
   GitHub secrets
 subquestion: |
-  For tests to work, a repository needs [GitHub secrets](https://docs.github.com/en/actions/reference/encrypted-secrets) set by the organization or repo admin. What is the status of the secrets now? If you don't know, ask the admin of the organization or repository if these secrets are set:
+  For tests to work, a repository needs access to [GitHub secrets](https://docs.github.com/en/actions/reference/encrypted-secrets) set by the organization or repo admin. What is the status of the secrets now? If you don't know, ask the admin of the organization or repository if these secrets are set:
 
   ${ secrets_list }
   
-  ${ how_to_see_repo_secrets }
+  ${ how_to_see_repo_secrets } ${ check_secrets_access }
+  
+  Does the package have access to those secrets?
 fields:
-  - Does the package have access to those secrets?: has_secrets
-    datatype: radio
-    choices:
-      - The package has access to those secrets: True
-      - The repository has those secrets: repo
+  - The repository has access to organization secrets: has_secrets
+    datatype: yesnowide
+  - The repository has access to repository secrets: has_secrets
+    datatype: yesnowide
+validation code: |
+  if not has_secrets:
+    validation_error("The package must have access to these secrets for you to continue setting up tests.")
 ---
 template: how_to_see_repo_secrets
 content: |
   To see a repository's secrets, an admin can go to the same place as where they [set the repository's secrets](https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository).
+---
+template: check_secrets_access
+content: |
+  If the organization has these secrets, but those secrets are not showing up in the package's repository, the admin may need to [change the access levels for the secret](https://docs.github.com/en/actions/reference/encrypted-secrets#reviewing-access-to-organization-level-secrets).
 ---
 comment: |
   You need to be an organization admin to set up organization secrets. Contact your admin and give them a link to this interview so they can set up the organization secrets.

--- a/docassemble/ALAutomatedTestingTests/data/questions/al_set_up_testing.yml
+++ b/docassemble/ALAutomatedTestingTests/data/questions/al_set_up_testing.yml
@@ -39,8 +39,6 @@ code: |
   if len( installer.errors ) > 0:
     show_errors
   
-  installer.token = "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"
-  installer.owner_name = "alsjdflaskjdfiwfn"
   # Secrets
   if is_org_admin or is_repo_admin:
     wants_to_set_up_tests
@@ -633,4 +631,7 @@ code: |
 template: github_branch_name_error
 content: |
   It looks like all the allowed branch names are taken. To solve this, delete some of the branches that start with "${ installer.default_branch_name }".
+---
+include:
+  - temp.yml
 ---

--- a/docassemble/ALAutomatedTestingTests/data/questions/al_set_up_testing.yml
+++ b/docassemble/ALAutomatedTestingTests/data/questions/al_set_up_testing.yml
@@ -19,15 +19,6 @@ objects:
 include:
   - al_testing_files_to_push.yml
 ---
-comment: |
-  want to set org secrets
-    must be an org admin
-  want to set up tests for one package
-    have secrets
-      set up url
-    don't have secrets
-      need to be an admin and set up repo secrets
----
 mandatory: True
 code: |
   ## for dev
@@ -353,43 +344,6 @@ content: |
   "workflow" and "repo"
   % endif
 ---
-## TODO: Add link to docs where we explain how the library makes a project, etc.
-## TODO: Add links to the actual github repo and files and folders
-## TODO: only show 'other than you' if the person is logged in
-#id: intro personal repo
-#question: |
-#  Set up Document Assembly Line automated integrated testing
-#subquestion: |
-#  This interview will help you set up automated integrated GitHub testing for a docassemble package.
-#
-#  :clock: This could take about 40 minutes
-#  
-#  ---
-#  
-#  **Make sure:**
-#  
-#  * The package is in a GitHub repository.
-#  * You have admin permissions on the package's GitHub repository.
-#  * You are logged into the docassemble account where the tests will run.
-#  
-#  ---
-#
-#  **Sneak Peak**
-#
-#  This tool will add folders and files to the project:
-#
-#  ${ files_list }
-#  
-#  It will add 3 [GitHub "SECRETS"](https://docs.github.com/en/actions/reference/encrypted-secrets) to the repository to store encrypted information safely:
-#  
-#  ${ secrets_list }
-#  
-#  ---
-#  
-#  Your answers will be encrypted end-to-end and on the server. No one other than you will have access to them.
-#  
-#continue button field: repo_intro
----
 template: files_list
 content: |
   * **tests/features/example_test.feature** is a very simple example of a test.
@@ -605,7 +559,7 @@ template: github_url_error
 content: |
   Cannot validate the GitHub URL **"${ installer.repo_url }"**. Example of a valid URL:
   
-  `https://github.com/owner_name/repo_name`
+  **https://github.com/owner_name/repo_name**
   
   If you are sure you have the correct GitHub URL, please [file an issue](https://github.com/plocket/docassemble-ALAutomatedTestingTests) and include the GitHub URL.
 ---
@@ -617,7 +571,7 @@ template: github_repo_not_found_error
 content: |
   GitHub cannot find the **${ installer.repo_name }** repository owned by the owner **${ installer.owner_name }**. Example of a valid URL:
   
-  `https://github.com/owner_name/repo_name`
+  **https://github.com/owner_name/repo_name**
   
   You gave the repository address of **${ installer.repo_url }**. Are you sure that is correct?
 ---

--- a/docassemble/ALAutomatedTestingTests/data/questions/al_set_up_testing.yml
+++ b/docassemble/ALAutomatedTestingTests/data/questions/al_set_up_testing.yml
@@ -14,8 +14,6 @@ modules:
 ---
 objects:
   - installer: TestInstaller
-  # TODO: see if this can work instead of other shinannigans
-  #- has_secrets: DADict  #.using(there_are_any=False)
 ---
 include:
   - al_testing_files_to_push.yml
@@ -63,20 +61,13 @@ code: |
   installer.token
   set_github_auth
   
-  # TODO: next steps for secrets - ensure the secret has the access settings you want
-  
-  ##
-  ##
-  ### confirm
-  ##is_ready
-  ##
+  # confirm
+  is_ready
   # update github
   update_github
-  ##
-  ###instructions
-  ##force_ask( 'next_steps' )
   
-  force_ask( 'next_steps_org' )
+  #instructions
+  force_ask( 'next_steps' )
 ---
 code: |
   if will_test_on_this_server:
@@ -165,6 +156,7 @@ subquestion: |
   
   What do you want to do?
 fields:
+  # If is org admin
   - I want to set or update the organization's secrets: wants_to_set_org_secrets
     datatype: yesnowide
     js enable if: |
@@ -179,14 +171,12 @@ fields:
         is_org_admin
     js enable if: |
       !val('wants_to_set_org_secrets')
-  - I want to set or update the repository's secrets: wants_to_set_repo_secrets
-    datatype: yesnowide
-    show if:
-      code: |
-        not is_org_admin
   - I want to set up testing for a package: wants_to_set_up_tests
     datatype: yesnowide
   - note: A package must have access to GitHub secrets in order to run tests.
+    show if:
+      code: |
+        is_org_admin
     js show if: |
       val('wants_to_set_up_tests') && !val('wants_to_set_repo_secrets') && !val('wants_to_set_org_secrets')
   - no label: has_secrets
@@ -196,8 +186,35 @@ fields:
       - The package already has access to organization or repository secrets: yes
     help: |
       ${ how_to_see_repo_secrets } (see above for link)
+    show if:
+      code: |
+        is_org_admin
     js show if: |
       val('wants_to_set_up_tests') && !val('wants_to_set_repo_secrets') && !val('wants_to_set_org_secrets')
+  # Not org admin
+  - I want to set or update the repository's secrets: wants_to_set_repo_secrets
+    datatype: yesnowide
+    show if:
+      code: |
+        not is_org_admin
+  - note: A package must have access to GitHub secrets in order to run tests.
+    show if:
+      code: |
+        not is_org_admin
+    js show if: |
+      val('wants_to_set_up_tests') && !val('wants_to_set_repo_secrets')
+  - no label: has_secrets
+    datatype: checkboxes
+    none of the above: False
+    choices:
+      - The package already has access to organization or repository secrets: yes
+    help: |
+      ${ how_to_see_repo_secrets } (see above for link)
+    show if:
+      code: |
+        not is_org_admin
+    js show if: |
+      val('wants_to_set_up_tests') && !val('wants_to_set_repo_secrets')
 validation code: |
   # Define undefined values
   # Considered bad practice generally, but currently seems more maintainable
@@ -319,6 +336,14 @@ question: |
 subquestion: |
   You now need to create temporary authorization for GitHub using a [personal access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token).
   
+  % if wants_to_set_up_tests:
+  That token will let this tool add these folders and files to the repository on a new branch:
+  
+  ${ files_list }
+  
+  Then this interview will make a pull request with that branch.
+  % endif
+  
   1. Start making a [personal access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token). You will be able to delete it after you are finished here.
   % if wants_to_set_org_secrets:
   1. Tap the checkbox for "admin:org" permissions.
@@ -406,11 +431,11 @@ content: |
 ---
 template: files_list
 content: |
-  * `tests/features/example_test.feature` is a very simple example of a test.
-  * `.github/workflows/run_interview_tests.yml` tells GitHub when and how to run the tests.
-  * `package.json` lets GitHub load other packages it needs to run the tests.
-  * `.gitignore` is for developers who want to work in their local environment.
-  * `.env-example` can help guide developers who want to work in their local environment to set up the environment variables.
+  * tests/features/example_test.feature is a very simple example of a test.
+  * .github/workflows/run_interview_tests.yml tells GitHub when and how to run the tests and save the files created.
+  * package.json lets GitHub load other packages it needs to run the tests.
+  * .gitignore is for developers who want to work in their local environment.
+  * .env-example can help guide developers who want to work in their local environment to set up the environment variables.
 ---
 template: secrets_list
 content: |
@@ -421,7 +446,7 @@ content: |
 ---
 id: confirm info
 question: |
-  Is all this information correct?
+  Is this information correct?
 subquestion: |
   You will not be able to come back here after continuing.
 review:
@@ -445,48 +470,83 @@ review:
       ${ installer.server_url }
       
       ---
-  - Edit: installer.repo_url
+  - Edit: installer.token
     button: |
       #####GitHub repo and permission
       
+      * **Personal access token**: \*\*\*${ installer.token[-4:] }
+      
+      % if not wants_to_set_up_tests and wants_to_set_org_secrets:
+      * **Owner of the repository**:[BR]
+      ${ installer.owner_name }
+      % endif
+      
+      % if wants_to_set_up_tests or wants_to_set_repo_secrets:
       * **Repository URL**:[BR]
       [https://github.com/${ installer.owner_name }/${ installer.repo_name }](https://github.com/${ installer.owner_name }/${ installer.repo_name })
-      
-      * **Admin personal token**: Not shown
+      % endif
       
       ######**Your answers also gave us this information:**
       
       * **Your username**:[BR]
       ${ installer.user_name }
       
+      % if wants_to_set_up_tests or wants_to_set_repo_secrets:
       * **Owner of the repository**:[BR]
       ${ installer.owner_name }
+      % endif
       
       * **Package name**:[BR]
       ${ installer.package_name }
-  - note: Continue when you are ready. You will not be able to come back to this page.
+      
+      The new branch will be named ${ installer.branch_name }
+  - note: |
+      ---
+      There may be a few more steps after this to finish up. Continue when you are ready.
+      
+      You will not be able to come back to this page.
 continue button field: is_ready
-continue button label: Finish
+continue button label: Send to GitHub
 ---
 event: next_steps
 prevent going back: True
 question: |
-  Next steps
+  Your GitHub settings should be updated!
 subquestion: |
+  % if wants_to_set_up_tests:
   This should have created a [Pull Request in the package's GitHub repository](${ installer.pull_url }). New folders and files should have been added to the package:
   
   ${ files_list }
+  % endif
   
-  Also, 3 [GitHub "SECRETS"](https://docs.github.com/en/actions/reference/encrypted-secrets) were set to store encrypted docassemble login information safely:
+  % if wants_to_set_org_secrets or wants_to_set_repo_secrets:
+  3 [GitHub secrets](https://docs.github.com/en/actions/reference/encrypted-secrets) were set to store encrypted docassemble login information safely:
   
   ${ secrets_list }
+  % endif
   
   ---
   
-  To finish setup:
-
+  **Next**
+  
+  % if wants_to_set_repo_secrets or wants_to_set_org_secrets:
+  Secrets:
+  % endif
+  
+  % if wants_to_set_repo_secrets:
+  [Make sure the repository secrets got created](${ installer.repo.url }/settings/secrets/actions).
+  % endif
+  
+  % if wants_to_set_org_secrets:
+  1. [Make sure the organization secrets got created](${ installer.org.url }/settings/secrets/actions).
+  1. Make sure the secrets have the [access settings](https://docs.github.com/en/actions/reference/encrypted-secrets#reviewing-access-to-organization-level-secrets) you need.
+  % endif
+  
+  % if wants_to_set_up_tests:
+  New files:
+  
+  1. Make sure [the pull request](${ installer.pull_url }) got created.
   1. [Go to your actions page](https://github.com/${ installer.owner_name }/${ installer.repo_name }/actions) to see the first test being run. It may take a minute, but if all the information was correct it should pass and get a green checkmark.
-  1. Go to [the pull request](${ installer.pull_url }).
   1. [Request a review](https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) of that PR or just merge it.
   1. If the test fails the first time and gets a red "x", [rerun the test (a.k.a. the job)](https://docs.github.com/en/actions/managing-workflow-runs/re-running-a-workflow). If it fails again, contact us.
   1. Delete the [personal access token](https://github.com/settings/tokens) you created.
@@ -517,6 +577,15 @@ subquestion: |
   1. If it passes, make a pull request, request a review, and get the branch merged in.
 
   ---
+  % endif
+  
+  % if wants_to_set_org_secrets:
+  Team members that are collaborators can now use this interview to set up tests for their repositories without the need for organization-level permissions.
+  % endif
+  
+  % if not wants_to_set_up_tests:
+  Delete the [personal access token](https://github.com/settings/tokens) you created.
+  % endif
   
   You can read some rough docs at [https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/automated_integrated_testing](https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/automated_integrated_testing/).
   
@@ -527,18 +596,8 @@ buttons:
   - Restart: restart
 comment: |
   TODO: Should we offer to delete their personal access token for them in the interview itself? Do we have enough permissions?
-  TODO: Implement feedback form instead of linking issues. See AL core for that coming soon.
+  TODO: Implement feedback form instead of linking issues. See AL core for that.
   TODO: Add link to documentation on writing tests.
----
-event: next_steps_org
-question: |
-  Next steps
-subquestion: |
-  [Check that you have set up the secrets for your organization](https://github.com/organizations/${ installer.owner_name }/settings/secrets/actions)
-  
-  You should be finished. Your collaborators can now use this interview to set up testing for their repositories without the need for special permissions.
-buttons:
-  - Restart: restart
 ---
 id: show_errors
 event: show_errors
@@ -567,7 +626,7 @@ code: |
 ---
 template: github_pat_scopes_error
 content: |
-  The permission scope(s) of that [Github personal access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) are **${ comma_and_list( installer.github.oauth_scopes ) }**. What you are trying to do needs ${ token_permissions_scope } scope(s). You can try copying and pasting the token again or you can try [making a new one](https://github.com/settings/tokens). (This did not follow plain language guidelines, sorry)
+  What you are trying to do needs ${ token_permissions_scope } scope(s). The permission scope(s) of the [Github personal access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) ending in \*\*\*${ installer.token[-4:] } are **${ comma_and_list( installer.github.oauth_scopes ) }**. You can try copying and pasting the token again or you can try [making a new one](https://github.com/settings/tokens). (This disobeys plain language guidelines, sorry)
 ---
 depends on: github_token_error
 code: |
@@ -605,13 +664,13 @@ template: not_an_org_member_error
 content: |
   **${ installer.user_name }** might not be a member of **${ installer.owner_name }**. Try double checking the names.
 ---
-depends on: not_org_admin_error
+depends on: not_repo_admin_error
 code: |
-  installer.not_org_admin_error = not_org_admin_error.content
+  installer.not_repo_admin_error = not_repo_admin_error.content
 ---
-template: not_org_admin_error
+template: not_repo_admin_error
 content: |
-  **${ installer.user_name }** might not be an admin of **${ installer.owner_name }**. Try double checking the names.
+  **${ installer.user_name }** might not be an admin of **${ installer.repo_url }**. Try double checking the names.
 ---
 depends on: github_repo_not_found_error
 code: |

--- a/docassemble/ALAutomatedTestingTests/data/questions/al_set_up_testing.yml
+++ b/docassemble/ALAutomatedTestingTests/data/questions/al_set_up_testing.yml
@@ -125,7 +125,7 @@ fields:
     show if:
       code: |
         is_org_admin
-  - I want to set or update the repository's secrets: wants_to_set_repo_secrets
+  - I want to set or update a repository's secrets: wants_to_set_repo_secrets
     datatype: yesnowide
     show if:
       code: |
@@ -272,7 +272,7 @@ fields:
     datatype: password
   - note: |
       Go to the Playground of the account and run any working YAML file. For example, **test.yml**. What is the URL in the address bar? Example:[BR]
-      `https://legal-dev.org/interview?i=docassemble.playground22%3Atest.yml`
+      **https://legal-dev.org/interview?i=docassemble.playground22%3Atest.yml**
   - Interview URL: installer.playground_url
     hint: https://legal-dev.org/interview?i=docassemble.playground22%3Atest.yml
 
@@ -286,17 +286,22 @@ id: github auth
 question: |
   Authorizing for GitHub
 subquestion: |
-  You now need to create temporary authorization for GitHub using a [personal access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token).
+  This tool needs GitHub authorization - a [personal access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token). You can delete it at the end.
   
+  The token will let this tool:
+  
+  % if wants_to_set_repo_secrets or wants_to_set_org_secrets:
+  ${ '1.' if wants_to_set_up_tests else '' } Create or update GitHub secrets.
+  % endif
   % if wants_to_set_up_tests:
-  That token will let this tool add these folders and files to the repository on a new branch:
+  ${ '1.' if wants_to_set_repo_secrets or wants_to_set_org_secrets else '' } Add these folders and files to the repository on a new branch:
   
   ${ files_list }
   
   Then this interview will make a pull request with that branch.
   % endif
   
-  1. Start making a [personal access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token). You will be able to delete it after you are finished here.
+  1. Start making a [personal access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token).
   % if wants_to_set_org_secrets:
   1. Tap the checkbox for "admin:org" permissions.
   % endif
@@ -312,7 +317,7 @@ fields:
       The token must have ${ token_permissions_scope } permissions.
   - note: |
       We also need the GitHub repository URL of the package. Example:[BR]
-      `https://github.com/TheLawFantastic/docassemble-GreatForm`
+      **https://github.com/TheLawFantastic/docassemble-GreatForm**
     show if:
       code: |
         wants_to_set_up_tests or wants_to_set_repo_secrets
@@ -324,7 +329,7 @@ fields:
         wants_to_set_up_tests or wants_to_set_repo_secrets
   - note: |
       We also need the name of the GitHub organization. Example:[BR]
-      `SuffolkLITLab`
+      **SuffolkLITLab**
     show if:
       code: |
         not wants_to_set_up_tests and wants_to_set_org_secrets
@@ -392,11 +397,9 @@ review:
       * **Personal access token**: \*\*\*${ installer.token[-4:] }
       
       % if not wants_to_set_up_tests and wants_to_set_org_secrets:
-      * **Owner of the repository**:[BR]
+      * **GitHub organization**:[BR]
       ${ installer.owner_name }
-      % endif
-      
-      % if wants_to_set_up_tests or wants_to_set_repo_secrets:
+      % else:
       * **Repository URL**:[BR]
       [https://github.com/${ installer.owner_name }/${ installer.repo_name }](https://github.com/${ installer.owner_name }/${ installer.repo_name })
       % endif
@@ -411,12 +414,15 @@ review:
       ${ installer.owner_name }
       % endif
       
+      % if wants_to_set_up_tests:
       * **Package name**:[BR]
       ${ installer.package_name }
       
       The new branch will be named **${ installer.branch_name }**.
-  - note: |
+      % endif
+      
       ---
+  - note: |
       There may be a few more steps after this to finish up. Continue when you are ready.
       
       You will not be able to come back to this page.
@@ -449,11 +455,11 @@ subquestion: |
   % endif
   
   % if wants_to_set_repo_secrets:
-  [Make sure the repository secrets got created](${ installer.repo.url }/settings/secrets/actions).
+  [Make sure the repository secrets got created](https://github.com/${ installer.owner_name }/${ installer.repo_name }/settings/secrets/actions).
   % endif
   
   % if wants_to_set_org_secrets:
-  1. [Make sure the organization secrets got created](${ installer.org.url }/settings/secrets/actions).
+  1. [Make sure the organization secrets got created]( https://github.com/organizations/${ installer.org.login }/settings/secrets/actions).
   1. Make sure the secrets have the [access settings](https://docs.github.com/en/actions/reference/encrypted-secrets#reviewing-access-to-organization-level-secrets) you need.
   % endif
   
@@ -468,7 +474,7 @@ subquestion: |
 
   ---
   
-  Write your first test:
+  You can write your first test now if you want:
   
   1. Pull the new code into a new Project.
   1. In the Playground, go to your Sources folder.
@@ -483,7 +489,7 @@ subquestion: |
           Given I start the interview at "\\_\\_\\_\\_"
         </pre>
 
-  5. Replace `____` with the name of the YAML file you're testing.
+  5. Replace \\_\\_\\_\\_ with the name of the YAML file you're testing.
   1. Save the file.
   1. On your Packages page Sources section, select the file.
   1. Save the package.
@@ -495,7 +501,7 @@ subquestion: |
   % endif
   
   % if wants_to_set_org_secrets:
-  Team members that are collaborators can now use this interview to set up tests for their repositories without the need for organization-level permissions.
+  Team members that are collaborators can now use this interview to set up tests for their repositories without needing to set secrets.
   % endif
   
   % if not wants_to_set_up_tests:
@@ -506,7 +512,7 @@ subquestion: |
   
   ---
   
-  If you have some feedback, we would love to hear from you. [Make an "issue" in our repository](https://github.com/plocket/docassemble-ALAutomatedTestingTests/issues/new) or let us know in chat!
+  If you have some feedback, we would love to hear from you! Let us know in chat or [make a public "issue" in our repository](https://github.com/plocket/docassemble-ALAutomatedTestingTests/issues/new).
 buttons:
   - Restart: restart
 comment: |
@@ -520,10 +526,13 @@ question: |
   Sorry, something went wrong
 subquestion: |
   % for error in installer.errors:
-  **Error: ${ error.status if error.status else '' } ${ error.data[ 'message' ] }**${ '[BR]' + error.data[ 'details' ] }
-  <hr/>
+  **Error: ${ error.status if error.status else '' } ${ error.data[ 'message' ] }**[BR]
+  ${ error.data[ 'details' ] }
   
+  ---
   % endfor
+  
+  If you cannot find a way to fix the problem, contact us in chat or [file a public issue](https://github.com/plocket/docassemble-ALAutomatedTestingTests).
 ---
 depends on: da_url_error
 code: |
@@ -532,8 +541,7 @@ code: |
 template: da_url_error
 content: |
   Cannot validate the interview URL **"${ installer.playground_url }"**. Example of a valid URL:[BR]
-  `https://dev.court-wizards.org/interview?i=docassemble.playground222ProjectName%3Asome_file.yml` [BR]
-  If you are sure you have the whole URL of a running interview, please [file an issue](https://github.com/plocket/docassemble-ALAutomatedTestingTests) and include your interview URL in the report.
+  **https://dev.court-wizards.org/interview?i=docassemble.playground222ProjectName%3Asome_file.yml** [BR]
 ---
 depends on: github_token_error
 code: |
@@ -560,8 +568,6 @@ content: |
   Cannot validate the GitHub URL **"${ installer.repo_url }"**. Example of a valid URL:
   
   **https://github.com/owner_name/repo_name**
-  
-  If you are sure you have the correct GitHub URL, please [file an issue](https://github.com/plocket/docassemble-ALAutomatedTestingTests) and include the GitHub URL.
 ---
 depends on: github_repo_not_found_error
 code: |

--- a/docassemble/ALAutomatedTestingTests/data/questions/al_set_up_testing.yml
+++ b/docassemble/ALAutomatedTestingTests/data/questions/al_set_up_testing.yml
@@ -31,12 +31,11 @@ code: |
   if len( installer.errors ) > 0:
     show_errors
   
-  # role and goal
+  # Role
   is_org_admin
-  wants_to_set_up_tests
   
-  # Secrets
-  if wants_to_set_org_secrets or wants_to_set_repo_secrets:
+  # Needs
+  if secrets_need == 'org' or secrets_need == 'repo':
     get_secrets_info
   
   # Get and test github PAT (token) and either repo url or org name
@@ -61,16 +60,16 @@ code: |
   get_secrets_info = True
 ---
 code: |
+  installer.set_org_secrets()
+  set_org_secrets = True
+---
+code: |
   installer.set_da_info()
   set_da_info = True
 ---
 code: |
   installer.set_github_auth()
   set_github_auth = True
----
-code: |
-  installer.set_org_secrets()
-  set_org_secrets = True
 ---
 code: |
   if wants_to_set_up_tests:
@@ -88,10 +87,7 @@ code: |
   update_github = True
 ---
 auto terms:
-  - the docassemble account where the tests will run: Remember that **you can use your own account** and you can always change this later.
----
-comment: |
-  https://flowchart.fun/c#H4hQBsEME8HsFcAuAuUACNA7SBbApsmgCaQDmATnumuZJgNYAiAluYQDIBKoIwooAegBUAFQAWzAM5pIAB1loA7rHL1pAI2hpE0Wc0ylqASUxE8mRPtJoAxpUiI80yGnD7622NrF5b8cpQWrvpUGHRajgAeKGjqeABmKr4uNrDgsJi29o7OrpBx4NQYsIg+bGgAFDbwkoiwOGhGjACU1ADC2cnBDMSseDaI4Fo1Vt6+eJGQA3kF2hOIRcH0vqVShBXiUjLySipqsRG6Vq0YGADa1bX1jYwAumgqixiaMkREo3RoZ033dEQ0CTwgRso1KDiepzcy28a0qlzqDSazTQAgEaAAmghbJ9IOBJF4ar5JFZwHgALRuTC+VI4fAWSSgIQCQRCUCPHDwcCWSlUGl0xAM0AACUgADdfPF4JgAIRoQA8G4BI-cZzLZ5GskCIOH01BsdEIkjwiAearQBrshoZ50osi8knuusw+sNAJtpv6lAF1DOOQF9r1bqN8AUPrQ8WYpIZ1q8Gq1mB1-oqUdNJ2xjsqPskrRU1lSFnIzHUSEeGCqGUQ+fUrSTufLBaL5GopbzBdaFzLFfusJrFfr1GzaDEkGkZo9ltOFQzKaTg+H7otiwnTgFKcwtrnntOWC8GdAQA
+  the docassemble account where the tests will run: Remember that **you can use your own account** and you can always change this later.
 ---
 id: repo role
 question: |
@@ -101,128 +97,94 @@ subquestion: |
   
   :clock: This task can take up to 30 minutes.
   
-  What you can do depends on your situation and what kind of GitHub permissions you have.
+  What you can set up depends on your situation and what kind of GitHub permissions you have.
 fields:
   - Are you the admin of the organization?: is_org_admin
     datatype: yesnoradio
 ---
 # Note: any repo writer can set repo secrets
-id: admin goal
+id: needs
 question: |
-  What do you want to do?
+  What do you need to do?
 subquestion: |
-  For tests to run, they need to be able to autmoatically make a Project on your docassemble server and then run an interview from that Project. To do that, the repository need access to organization or repository secrets and some extra files. Once an organization admin sets up organization secrets, repository secrets are unnecessary.
+  % if is_org_admin:
+  You said you are the admin of an organization.
   
-  This tool can help set up secrets, add testing files to a repository, or both. If you might need to add secrets, tap the "About Github secrets" help button at the bottom of the page to learn more.
+  Using this form you can {set up GitHub secrets}, or set up the testing package files in a repository, or both. If you set up secrets, you can choose to create secrets for your organization or for a specific repository.
+  % else:
+  You said you are a developer on a repository and can change files in a repository.
   
-  What do you want to do?
+  Using this form you can {set up GitHub secrets} for a repository, or set up the testing package files in a repository, or both.
+  % endif
+  
+  Note that if an organization admin has already set up **organization** secrets, repositories of that organiation don't need their own secrets.
+  %if not is_org_admin:
+  If you want your organization admin to set up organization secrets, give them a link to this tool.
+  % endif
+  
+  What do you need?
 fields:
   # If is org admin
-  - I want to set or update the organization's secrets: wants_to_set_org_secrets
-    datatype: yesnowide
-    js enable if: |
-      !val('wants_to_set_repo_secrets')
+  - What kind of secrets do you need to set up?: secrets_need
+    datatype: radio
     show if:
       code: |
         is_org_admin
-  - I want to set or update a repository's secrets: wants_to_set_repo_secrets
-    datatype: yesnowide
-    show if:
-      code: |
-        is_org_admin
-    js enable if: |
-      !val('wants_to_set_org_secrets')
+    choices:
+      - My organization's secrets: org
+      - A repository's secrets: repo
+      - I already have the secrets I need: none
   # Not org admin
-  - I want to set or update the repository's secrets: wants_to_set_repo_secrets
-    datatype: yesnowide
+  - What do you need to do about secrets?: secrets_need
+    datatype: radio
     show if:
       code: |
         not is_org_admin
+    choices:
+      - I need to set up a repository's secrets: repo
+      - I already have the secrets I need: none
   # Always
-  - I want to set up testing for a package: wants_to_set_up_tests
-    datatype: yesnowide
-  # Is org admin
-  - note: A package must have access to GitHub secrets in order to run tests.
-    show if:
-      code: |
-        is_org_admin
-    js show if: |
-      val('wants_to_set_up_tests') && !val('wants_to_set_repo_secrets') && !val('wants_to_set_org_secrets')
-  - no label: has_secrets
-    datatype: checkboxes
-    none of the above: False
-    choices:
-      - The package already has access to organization or repository secrets: yes
-    help: Tap the "About Github secrets" help button for more info
-    show if:
-      code: |
-        is_org_admin
-    js show if: |
-      val('wants_to_set_up_tests') && !val('wants_to_set_repo_secrets') && !val('wants_to_set_org_secrets')
-  # Not org admin
-  - note: A package must have access to GitHub secrets in order to run tests.
-    show if:
-      code: |
-        not is_org_admin
-    js show if: |
-      val('wants_to_set_up_tests') && !val('wants_to_set_repo_secrets')
-  - no label: has_secrets
-    datatype: checkboxes
-    none of the above: False
-    choices:
-      - The package already has access to organization or repository secrets: yes
-    help: Tap the "About Github secrets" help button for more info
-    show if:
-      code: |
-        not is_org_admin
-    js show if: |
-      val('wants_to_set_up_tests') && !val('wants_to_set_repo_secrets')
+  - Do you need to set up testing for a package?: wants_to_set_up_tests
+    datatype: yesnoradio
 validation code: |
-  # Define undefined values
-  # Considered bad practice generally, but currently seems more maintainable
-  # If it becomes less maintainable, we can move this elsewhere
-  if not defined('wants_to_set_org_secrets'):
-    wants_to_set_org_secrets = False
-  if not defined('wants_to_set_repo_secrets'):
-    wants_to_set_repo_secrets = False
-  if not defined('has_secrets'):
-    has_secrets = DADict('has_secrets', there_are_any=False)  # None are true
-    
-  # Validate
-  if (wants_to_set_up_tests
-      and not wants_to_set_org_secrets
-      and not wants_to_set_repo_secrets
-      and not has_secrets.any_true()):
-    validation_error("If you want to set up tests and the package does not have access to secrets, you must choose a way to set secrets.")
-  if (not wants_to_set_up_tests
-      and not wants_to_set_org_secrets
-      and not wants_to_set_repo_secrets):
-    validation_error("You must mark at least one choice.")
+  if secrets_need == 'none' and not wants_to_set_up_tests:
+    validation_error("If you don't want to set secrets and don't want to set up tests, there is nothing to do here.")
+terms:
+  set up GitHub secrets: ${ secrets_popover }
 help:
-  label: |
-    About GitHub secrets
-  content: |
-    **About GitHub secrets:**
+  label: About GitHub secrets
+  content: ${ about_secrets }
+---
+template: secrets_popover
+content: |
+  Tap the "About GitHub Secrets" button at the bottom of the page to learn why the tests need GitHub secrets and how to see what secrets you already have.
+---
+template: about_secrets
+content: |
+    **About GitHub secrets**
 
-    [GitHub secrets](https://docs.github.com/en/actions/reference/encrypted-secrets) store and encrypt the information the tests need in order to autmoatically make a Project on your docassemble server and then run an interview from that Project. This tool can help you set these secrets:
+    [GitHub secrets](https://docs.github.com/en/actions/reference/encrypted-secrets) encrypt and store sensitive information that the automated tests need.
+
+    When you commit or push a file to GitHub, the automated tests will tell GitHub to:
+    
+    1. Log into a docassemble account on your server.
+    1. Make a new Project. The name will start with "testing".
+    1. Pull your package's GitHub code from the branch that they are testing.
+    1. Go through the interview as if the tests were a real person.
+
+    To do that first step, the automated tests need to know a user name and password to use to log into a developer account on your server.
+
+    If you choose to set up secrets, your answers will help this tool set these secrets:
 
     ${ secrets_list }
-    
-    If you're not sure what your organization secrets are, an org admin can [see them in the same place that they can create them](https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-an-organization).
-    
-    If you're not sure what your repository secrets are, a repository admin can [see them in the same place that they can create them](https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository).
-    
-    If you're not sure whether a repository has access to an organization's secrets, a repository admin can see those on the repository's secrets page too (described above).
-    
-    If the organization has these secrets, but those secrets are not showing up in the package's repository, the organization admin may need to [change the access settings for the secret](https://docs.github.com/en/actions/reference/encrypted-secrets#reviewing-access-to-organization-level-secrets).
-  
----
-id: no admin or secrets kickout
-event: needs_secrets_kickout
-question: |
-  The repository needs secrets
-subquestion: |
-  To get these tests to run, an admin needs to set up secrets. Contact your admin and give them a link to this interview. It will help them set up the right secrets.
+
+    If you're not sure what secrets your organization has set, an org admin can [see them in the same place that they can create them](https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-an-organization).
+
+    If you're not sure what secrets your repository has, a repository admin can [see them in the same place that they can create them](https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository).
+
+    If you're not sure whether a repository has access to its organization's secrets, a repository admin can see those on the repository's secrets page too, as described above.
+
+    If the organization has these secrets, but the secrets are not showing up in the package's repository, the organization admin may need to [change the access settings for the secret](https://docs.github.com/en/actions/reference/encrypted-secrets#reviewing-access-to-organization-level-secrets).
 ---
 id: on testing server
 question: |
@@ -235,20 +197,36 @@ id: logged_into_test_account_on_interview_server
 question: |
   What account are you logged in on?
 subquestion: |
+  You, your team, or your organiztion might {want to set up an account just for running tests}. The tests can also just run on your account.
+
   Are you logged into the docassemble account where the tests will run?
 yesno: logged_into_test_account_on_interview_server
+terms:
+  want to set up an account just for running tests: |
+    Tap the "Why have a testing account?" button below to learn why you might want to set up an account just for running tests.
+help:
+  label: Why have a testing account?
+  content: ${ why_special_account }
+---
+template: why_special_account
+content: |
+  **Why would you want to set up an account just for testing?**
+  
+  First, GitHub will use that account. It will put special Projects on it and put files in those project, then it will delete them. If a developer is using that docassemble account, they may find it confusing.
+  
+  Secondly, it may cause problems later on. Imagine that the tests are set up to run on a developer's account. Then the developer leaves the team and deletes their account. The tests will fail because the account is missing.
 ---
 id: log_into_test_account
 question: |
   Before you continue
 subquestion: |
-  You will probably need to log into the account where the tests will run. Since this form is on the same server and you are not logged into that account, you can do one of 3 things:
+  To help you answer the following questions, you may want to log into the account where the tests will run. Since this form is on the same server as this interview and you are not logged into that account, you can do one of 3 things:
   
-  * Open an incognito window and log into that account there.
-  * Go to a different browser to log into that account.
-  * Leave this interview, log into the account, and start this interview again.
+  * [Open an incognito window](https://techbrightsystems.com/incognito-mode/) and log into that account there.
+  * Log into that account on a different browser.
+  * Leave this interview, log into that account, and start this interview again.
 
-  Tap to continue when you have done one of those.
+  Tap to continue when you are ready.
 
 continue button field: log_into_test_account
 ---
@@ -256,7 +234,7 @@ id: da server info
 question: |
   GitHub secrets
 subquestion: |
-  As described, the tests need access to server login information. This tool will help you set up these encrypted [GitHub secrets](https://docs.github.com/en/actions/reference/encrypted-secrets):
+  As described, {the tests need some GitHub secrets}. This tool will help you set up these encrypted [GitHub secrets](https://docs.github.com/en/actions/reference/encrypted-secrets):
   
   ${ secrets_list }
 
@@ -271,14 +249,16 @@ fields:
   - Account password: installer.password
     datatype: password
   - note: |
-      Go to the Playground of the account and run any working YAML file. For example, **test.yml**. What is the URL in the address bar? Example:[BR]
+      Go to the Playground of the account and run any working YAML file. For example, **test.yml**. What is {the URL in the address bar}? Example:[BR]
       **https://legal-dev.org/interview?i=docassemble.playground22%3Atest.yml**
   - Interview URL: installer.playground_url
-    hint: https://legal-dev.org/interview?i=docassemble.playground22%3Atest.yml
-
-auto terms:
-  - the URL in the address bar: |
-      The interview URL will give us the account's Playground ID and the address of the server that the account is on.
+terms:
+  the URL in the address bar: |
+    The interview URL will give us the account's Playground ID and the address of the server that the account is on.
+  the tests need some GitHub secrets: ${ secrets_popover }
+help:
+  label: About GitHub secrets
+  content: ${ about_secrets }
 ---
 # TODO: Can an org admin sometimes not have push access to an org repo?
 # TODO: Will org admins try to also add tests to a non-org repo?
@@ -290,11 +270,11 @@ subquestion: |
   
   The token will let this tool:
   
-  % if wants_to_set_repo_secrets or wants_to_set_org_secrets:
+  % if secrets_need == 'repo' or secrets_need == 'org':
   ${ '1.' if wants_to_set_up_tests else '' } Create or update GitHub secrets.
   % endif
   % if wants_to_set_up_tests:
-  ${ '1.' if wants_to_set_repo_secrets or wants_to_set_org_secrets else '' } Add these folders and files to the repository on a new branch:
+  ${ '1.' if secrets_need == 'repo' or secrets_need == 'org' else '' } Add these folders and files to the repository on a new branch:
   
   ${ files_list }
   
@@ -302,10 +282,10 @@ subquestion: |
   % endif
   
   1. Start making a [personal access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token).
-  % if wants_to_set_org_secrets:
+  % if secrets_need == 'org':
   1. Tap the checkbox for "admin:org" permissions.
   % endif
-  % if wants_to_set_up_tests or wants_to_set_repo_secrets:
+  % if wants_to_set_up_tests or secrets_need == 'repo':
   1. Tap the checkbox for "workflow" permissions. That should also trigger "repo" permissions.
   % endif
   1. Finish creating the token.
@@ -320,30 +300,30 @@ fields:
       **https://github.com/TheLawFantastic/docassemble-GreatForm**
     show if:
       code: |
-        wants_to_set_up_tests or wants_to_set_repo_secrets
+        wants_to_set_up_tests or secrets_need == 'repo'
   - Repo URL: installer.repo_url
     help: |
       The repository's URL will give us the name of the repo and its owner.
     show if:
       code: |
-        wants_to_set_up_tests or wants_to_set_repo_secrets
+        wants_to_set_up_tests or secrets_need == 'repo'
   - note: |
       We also need the name of the GitHub organization. Example:[BR]
       **SuffolkLITLab**
     show if:
       code: |
-        not wants_to_set_up_tests and wants_to_set_org_secrets
+        not wants_to_set_up_tests and secrets_need == 'org'
   - Organization name: installer.owner_name
     show if:
       code: |
-        not wants_to_set_up_tests and wants_to_set_org_secrets
+        not wants_to_set_up_tests and secrets_need == 'org'
 ---
 # TODO: discuss: Really if just setting repo secrets, only need repo permissions, but do we want to make it that complicated/inconsistent?
 template: token_permissions_scope
 content: |
-  % if wants_to_set_org_secrets and wants_to_set_up_tests:
+  % if secrets_need == 'org' and wants_to_set_up_tests:
   "admin:org", "workflow", and "repo"
-  % elif wants_to_set_org_secrets and not wants_to_set_up_tests:
+  % elif secrets_need == 'org' and not wants_to_set_up_tests:
   "admin:org"
   % else:
   "workflow" and "repo"
@@ -394,9 +374,9 @@ review:
     button: |
       #####GitHub repo and permission
       
-      * **Personal access token**: \*\*\*${ installer.token[-4:] }
+      * **Personal access token**: \*\*\*\*${ installer.token[-4:] }
       
-      % if not wants_to_set_up_tests and wants_to_set_org_secrets:
+      % if not wants_to_set_up_tests and secrets_need == 'org':
       * **GitHub organization**:[BR]
       ${ installer.owner_name }
       % else:
@@ -409,7 +389,7 @@ review:
       * **Your username**:[BR]
       ${ installer.user_name }
       
-      % if wants_to_set_up_tests or wants_to_set_repo_secrets:
+      % if wants_to_set_up_tests or secrets_need == 'repo':
       * **Owner of the repository**:[BR]
       ${ installer.owner_name }
       % endif
@@ -440,8 +420,8 @@ subquestion: |
   ${ files_list }
   % endif
   
-  % if wants_to_set_org_secrets or wants_to_set_repo_secrets:
-  3 [GitHub secrets](https://docs.github.com/en/actions/reference/encrypted-secrets) were set to store encrypted docassemble login information safely:
+  % if secrets_need == 'org' or secrets_need == 'repo':
+  3 [GitHub secrets](https://docs.github.com/en/actions/reference/encrypted-secrets) were set to store {encrypted docassemble login information} safely:
   
   ${ secrets_list }
   % endif
@@ -450,15 +430,15 @@ subquestion: |
   
   **Next**
   
-  % if wants_to_set_repo_secrets or wants_to_set_org_secrets:
+  % if secrets_need == 'repo' or secrets_need == 'org':
   Secrets:
   % endif
   
-  % if wants_to_set_repo_secrets:
+  % if secrets_need == 'repo':
   [Make sure the repository secrets got created](https://github.com/${ installer.owner_name }/${ installer.repo_name }/settings/secrets/actions).
   % endif
   
-  % if wants_to_set_org_secrets:
+  % if secrets_need == 'org':
   1. [Make sure the organization secrets got created]( https://github.com/organizations/${ installer.org.login }/settings/secrets/actions).
   1. Make sure the secrets have the [access settings](https://docs.github.com/en/actions/reference/encrypted-secrets#reviewing-access-to-organization-level-secrets) you need.
   % endif
@@ -500,7 +480,7 @@ subquestion: |
   ---
   % endif
   
-  % if wants_to_set_org_secrets:
+  % if secrets_need == 'org':
   Team members that are collaborators can now use this interview to set up tests for their repositories without needing to set secrets.
   % endif
   
@@ -515,6 +495,11 @@ subquestion: |
   If you have some feedback, we would love to hear from you! Let us know in chat or [make a public "issue" in our repository](https://github.com/plocket/docassemble-ALAutomatedTestingTests/issues/new).
 buttons:
   - Restart: restart
+terms:
+  encrypted docassemble login information: ${ secrets_popover }
+help:
+  label: About GitHub secrets
+  content: ${ about_secrets }
 comment: |
   TODO: Should we offer to delete their personal access token for them in the interview itself? Do we have enough permissions?
   TODO: Implement feedback form instead of linking issues. See AL core for that.

--- a/docassemble/ALAutomatedTestingTests/data/questions/al_set_up_testing.yml
+++ b/docassemble/ALAutomatedTestingTests/data/questions/al_set_up_testing.yml
@@ -44,7 +44,7 @@ code: |
   
   # confirm
   is_ready
-  # update github
+  # send the secrets and files to github
   update_github
   
   force_ask( 'next_steps' )
@@ -99,7 +99,7 @@ subquestion: |
   
   What you can set up depends on your situation and what kind of GitHub permissions you have.
 fields:
-  - Are you the admin of the organization?: is_org_admin
+  - Are you the admin of the GitHub "organization"?: is_org_admin
     datatype: yesnoradio
 ---
 # Note: any repo writer can set repo secrets
@@ -117,7 +117,8 @@ subquestion: |
   Using this form you can {set up GitHub secrets} for a repository, or set up the testing package files in a repository, or both.
   % endif
   
-  Note that if an organization admin has already set up **organization** secrets, repositories of that organiation don't need their own secrets.
+  Note that if a GitHub organization admin has already set up GitHub **organization** secrets, repositories that belong to the organization don't need their own secrets. Otherwise, a repository will need its own secrets.
+  
   %if not is_org_admin:
   If you want your organization admin to set up organization secrets, give them a link to this tool.
   % endif
@@ -133,7 +134,7 @@ fields:
     choices:
       - My organization's secrets: org
       - A repository's secrets: repo
-      - I already have the secrets I need: none
+      - Someone has set up the secrets already: none
   # Not org admin
   - What do you need to do about secrets?: secrets_need
     datatype: radio
@@ -142,7 +143,7 @@ fields:
         not is_org_admin
     choices:
       - I need to set up a repository's secrets: repo
-      - I already have the secrets I need: none
+      - Someone has set up the repository or organization secrets already: none
   # Always
   - Do you need to set up testing for a package?: wants_to_set_up_tests
     datatype: yesnoradio
@@ -161,9 +162,37 @@ content: |
 ---
 template: about_secrets
 content: |
-    **About GitHub secrets**
+    **What are GitHub secrets?**
 
-    [GitHub secrets](https://docs.github.com/en/actions/reference/encrypted-secrets) encrypt and store sensitive information that the automated tests need.
+    [GitHub secrets](https://docs.github.com/en/actions/reference/encrypted-secrets) encrypt and store sensitive information that the automated tests need. To read more about why, go to the last section on this page.
+    
+    ---
+    
+    **Who can set a GitHub secret?**
+    
+    An admin of a GitHub **organization** can set the secrets for that GitHub organization. They can do that through this tool or just on GitHub itself. They can also set the secrets in repositories that belong to that organization.
+    
+    An admin of a GitHub **repository** can set the secrets for that GitHub repository on the GitHub website itself.
+    
+    A collaborator of a GitHub **repository** can set the secrets for the GitHub repository through **this tool**. A non-admin is unable to set secrets on GitHub itself. Yes, it's confusing. We don't know GitHub works that way ¯\_(ツ)_/¯
+    
+    ---
+
+    **Does my repository or organization already have GitHub secrets?**
+    
+    A non-admin cannot see organization or repository secrets. They will have to ask an admin.
+    
+    If you're not sure what secrets your organization has set, ask an **org admin** to take a look. They can [see them in the same place that they can create them](https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-an-organization).
+
+    If you're not sure what secrets your repository has, ask a **repository admin** to take a look. They can [see them in the same place that they can create them](https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository).
+
+    If you're not sure whether a repository has access to its organization's secrets, ask a repository admin to take a look. They can see those on the repository's secrets page too, as described above.
+
+    If the organization has these secrets, but the secrets are not showing up in the package's repository, the organization admin may need to [change the access settings for the secret](https://docs.github.com/en/actions/reference/encrypted-secrets#reviewing-access-to-organization-level-secrets).
+    
+    ---
+
+    **Why do these tests need GitHub secrets?**
 
     When you commit or push a file to GitHub, the automated tests will tell GitHub to:
     
@@ -171,20 +200,13 @@ content: |
     1. Make a new Project. The name will start with "testing".
     1. Pull your package's GitHub code from the branch that they are testing.
     1. Go through the interview as if the tests were a real person.
+    1. Delete the Project it created.
 
-    To do that first step, the automated tests need to know a user name and password to use to log into a developer account on your server.
+    To do some of those steps, the automated tests need to know a user name and password to use to log into a developer account on your server.
 
     If you choose to set up secrets, your answers will help this tool set these secrets:
 
     ${ secrets_list }
-
-    If you're not sure what secrets your organization has set, an org admin can [see them in the same place that they can create them](https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-an-organization).
-
-    If you're not sure what secrets your repository has, a repository admin can [see them in the same place that they can create them](https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository).
-
-    If you're not sure whether a repository has access to its organization's secrets, a repository admin can see those on the repository's secrets page too, as described above.
-
-    If the organization has these secrets, but the secrets are not showing up in the package's repository, the organization admin may need to [change the access settings for the secret](https://docs.github.com/en/actions/reference/encrypted-secrets#reviewing-access-to-organization-level-secrets).
 ---
 id: on testing server
 question: |
@@ -212,7 +234,7 @@ template: why_special_account
 content: |
   **Why would you want to set up an account just for testing?**
   
-  First, GitHub will use that account. It will put special Projects on it and put files in those project, then it will delete them. If a developer is using that docassemble account, they may find it confusing.
+  First, GitHub will use that account. It will create Projects in there, put files in those Projects, then it will delete those Projects. If a developer is using that docassemble account, they may find it confusing.
   
   Secondly, it may cause problems later on. Imagine that the tests are set up to run on a developer's account. Then the developer leaves the team and deletes their account. The tests will fail because the account is missing.
 ---

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(name='docassemble.ALAutomatedTestingTests',
       url='https://docassemble.org',
       packages=find_packages(),
       namespace_packages=['docassemble'],
-      install_requires=['PyGithub>=1.54.1', 'PyNaCl>=1.4.0', 'requests>=2.25.1'],
+      install_requires=['PyGithub>=1.55', 'PyNaCl>=1.4.0', 'requests>=2.25.1'],
       zip_safe=False,
       package_data=find_package_data(where='docassemble/ALAutomatedTestingTests/', package='docassemble.ALAutomatedTestingTests'),
      )


### PR DESCRIPTION
This one is pretty darn huge. We can get together and talk about it. It also has a lot of paths to test. I _think_ I've tested all the happy paths, which you can see in #148. There are a lot of even happy paths, though, and you don't have to do all of them. You might just pick three to test or something. It'll be a bit painful, but we can discover the bugs as people use it.

For the tests, I've set up a couple organizations and repos. You need to be an admin of one organization and you need to be a non-admin for the other org and have write-permissions for a repo there. There are other permutations, but I think those are really the two edge cases.

It turns out adding org secrets into the mix splits off paths something fierce. It meant I also had to add repository secrets so people could avoid setting them if their org already had secrets. And so on. Bleh. There are probably things that can be simplified or limited, but this is what I ended up with for the moment. We can think about adjustments, but for non-crucial ideas we'll make issues.

Closes #140 I think.

Example docassemble input:
- a@example.com
- lskdjflsdkjfldskjfldsj
- https://apps-dev.suffolklitlab.org/interview?i=docassemble.playground234ALTestingSetupOrg%3Aal_set_up_testing.yml#page1