### PR TITLE
Setup: Allow dev to include test choosing from list of possible files

### DIFF
--- a/docassemble/ALAutomatedTestingTests/al_set_up_testing.py
+++ b/docassemble/ALAutomatedTestingTests/al_set_up_testing.py
@@ -329,7 +329,8 @@ class TestInstaller(DAObject):
       test_path = 'docassemble/' + self.package_name + '/data/sources/interviews_run.feature'
       test_commit_message = 'Add ' + test_path + ' for ALKiln automated tests'
       self.send_file( test_path, test_commit_message, self.first_feature_file_str )  # 1
-    # Push the other files
+      
+    # Push the mandatory files
     self.send_file( '.env_example', 'Add .env_example for ALKiln automated tests', self.env_example_str )  # 2
     self.send_file( '.gitignore', 'Add .gitignore for ALKiln automated tests', self.gitignore_str )  # 3
     self.send_file( 'package.json', 'Add package.json for ALKiln automated tests', self.package_json_str )  # 4

--- a/docassemble/ALAutomatedTestingTests/al_set_up_testing.py
+++ b/docassemble/ALAutomatedTestingTests/al_set_up_testing.py
@@ -7,7 +7,7 @@ import codecs
 from base64 import b64encode
 import re
 import json
-from docassemble.base.util import log, value
+from docassemble.base.util import log, value, defined
 from docassemble.base.core import DAObject
 
 # reference:
@@ -295,24 +295,56 @@ class TestInstaller(DAObject):
     
     return self
   
+  def get_question_file_names( self ):
+    """Get the names of the files in the `questions` folder.
+    See https://pygithub.readthedocs.io/en/latest/examples/Repository.html#get-all-of-the-contents-of-the-repository-recursively
+    """
+    ## Don't know how to implement this so it'll recalculate when needed
+    ## Maybe `depends on: installer.github_url`?
+    #if self.hasattr( 'question_file_names' ):
+    #  return self.question_file_names
+    #else:
+    
+    # Get the path to the "questions" folder
+    package_path = ""
+    # Get the (only possible?) folder inside the "docassemble" folder
+    contents = self.repo.get_contents(f"docassemble")
+    for item in contents:
+        if item.type == "dir":
+            package_path = f"{ item.path }/data/questions"
+
+    # Get the names of the files in the "questions" folder
+    question_files = self.repo.get_contents( package_path )
+    names = []
+    for file in question_files:
+      names.append( file.name )
+    
+    #self.question_file_names = names
+    return names
+  
   def push_files( self ):
-    """Send files to folders in new branch in github."""
-    test_path = 'docassemble/' + self.package_name + '/data/sources/example_test.feature'
-    test_commit_message = 'Add ' + test_path
-    self.send_file( test_path, test_commit_message, self.example_test_str )  # 2
-    self.send_file( '.env_example', 'Add .env_example', self.env_example_str )  # 1
-    self.send_file( '.gitignore', 'Add .gitignore', self.gitignore_str )  # 3
-    self.send_file( 'package.json', 'Add package.json', self.package_json_str )  # 4
-    self.send_file( '.github/workflows/run_form_tests.yml', 'Add .github/workflows/run_form_tests.yml', self.run_form_tests_str )  # 5
+    """Push each file to the new branch in github in the correct directory."""
+    # Only push test if they wanted it
+    if self.test_files_wanted.any_true():
+      test_path = 'docassemble/' + self.package_name + '/data/sources/interviews_run.feature'
+      test_commit_message = 'Add ' + test_path + ' for ALKiln automated tests'
+      self.send_file( test_path, test_commit_message, self.first_feature_file_str )  # 1
+    # Push the other files
+    self.send_file( '.env_example', 'Add .env_example for ALKiln automated tests', self.env_example_str )  # 2
+    self.send_file( '.gitignore', 'Add .gitignore for ALKiln automated tests', self.gitignore_str )  # 3
+    self.send_file( 'package.json', 'Add package.json for ALKiln automated tests', self.package_json_str )  # 4
+    self.send_file( '.github/workflows/run_form_tests.yml', 'Add .github/workflows/run_form_tests.yml for ALKiln automated tests', self.run_form_tests_str )  # 5
+    
     return self
   
   def send_file( self, path, msg, contents ):
-    """Either create a new file or update an existing file with the given data.
+    """Either create a new file or update an existing file with the given data
+       and push it to new branch.
        See https://stackoverflow.com/a/66673303/14144258.
        TODO: Discuss removing `self` to make it data-based.
-       TODO: Shall we include the committer's user name, etc?"""
+       TODO: Shall we remove the committer's user name/email?"""
     
-    #https://pygithub.readthedocs.io/en/latest/examples/Repository.html#create-a-new-file-in-the-repository'''
+    #https://pygithub.readthedocs.io/en/latest/examples/Repository.html#create-a-new-file-in-the-repository
     # https://pygithub.readthedocs.io/en/latest/github_objects/Repository.html#github.Repository.Repository.create_file
     try:
       # Try to create the file
@@ -334,14 +366,19 @@ class TestInstaller(DAObject):
     # TODO: Check mergability of a PR?
     base_name = self.repo.default_branch
     head_name = self.branch_name
-    title = 'Update to automated tests'  # TODO: Add issue # if desired
-    description = '''Updates:
-- [x] .env_example
-- [x] tests/features/example_test.feature
-- [x] .gitignore
-- [x] package.json
-- [x] .github/workflows/run_form_tests.yml
-'''  # TODO: Add issue # if desired
+    title = 'Add ALKiln automated tests'  # TODO: Add issue # if desired
+    description = '''Added these files:'''
+    if self.test_files_wanted.any_true():
+      description += '''
+- tests/features/interviews_run.feature'''
+    description += '''
+- .github/workflows/run_form_tests.yml
+- .env_example
+- .gitignore
+- package.json
+
+Want to disable the tests? See documentation for ALKiln tests at https://suffolklitlab.github.io/docassemble-AssemblyLine-documentation/docs/automated_integrated_testing.
+'''
     response = self.repo.create_pull(base=base_name, head=head_name, title=title, body=description)
     self.pull_url = response.html_url
     

--- a/docassemble/ALAutomatedTestingTests/data/questions/al_set_up_testing.yml
+++ b/docassemble/ALAutomatedTestingTests/data/questions/al_set_up_testing.yml
@@ -21,10 +21,10 @@ include:
 mandatory: True
 code: |
   ## for dev
-  installer.repo_url = 'https://github.com/plocket/docassemble-ALAutomatedTestingTests'
-  installer.playground_url = 'https://apps-dev.suffolklitlab.org/interview?i=docassemble.playground12ProjectName%3Aal_set_up_testing.yml#page4'
-  installer.email = 'a@example.com'
-  installer.password = 'asldkjflsdkjfldsjflsdjf'
+  #installer.repo_url = 'https://github.com/plocket/docassemble-ALAutomatedTestingTests'
+  #installer.playground_url = 'https://apps-dev.suffolklitlab.org/interview?i=docassemble.playground12ProjectName%3Aal_set_up_testing.yml#page4'
+  #installer.email = 'a@example.com'
+  #installer.password = 'asldkjflsdkjfldsjflsdjf'
   
   # show errors first thing on each loop
   if len( installer.errors ) > 0:
@@ -558,7 +558,7 @@ review:
       * **Package name**:[BR]
       ${ installer.package_name }
       
-      * **Test files**:[BR]\
+      * **Files to test**:[BR]\
       % if installer.test_files_wanted.any_true():
       % for test_file in installer.test_files_wanted.true_values():
       ${ test_file }[BR]

--- a/docassemble/ALAutomatedTestingTests/data/questions/al_set_up_testing.yml
+++ b/docassemble/ALAutomatedTestingTests/data/questions/al_set_up_testing.yml
@@ -21,10 +21,10 @@ include:
 mandatory: True
 code: |
   ## for dev
-  ##installer.repo_url = 'https://github.com/plocket/install'
-  #installer.playground_url = 'https://apps-dev.suffolklitlab.org/interview?i=docassemble.playground12ALTestingGHSendFiles%3Aal_set_up_testing.yml#page4'
-  #installer.email = 'a@example.com'
-  #installer.password = 'asldkjflsdkjfldsjflsdjf'
+  installer.repo_url = 'https://github.com/plocket/docassemble-ALAutomatedTestingTests'
+  installer.playground_url = 'https://apps-dev.suffolklitlab.org/interview?i=docassemble.playground12ProjectName%3Aal_set_up_testing.yml#page4'
+  installer.email = 'a@example.com'
+  installer.password = 'asldkjflsdkjfldsjflsdjf'
   
   # show errors first thing on each loop
   if len( installer.errors ) > 0:
@@ -46,7 +46,10 @@ code: |
   installer.token
   set_github_auth
   
-  # confirm
+  # Set them up with an example test file if they want
+  installer.test_files_wanted
+  
+  # review/confirm
   is_ready
   # send the secrets and files to github
   update_github
@@ -96,11 +99,11 @@ code: |
     # loops that end up creating 5 branches. It seemed to make
     # sense to put them in here.
     installer.env_example_str = installer.env_example.content
-    installer.example_test_str = installer.example_test.content
+    installer.first_feature_file_str = installer.first_feature_file.content
     installer.gitignore_str = installer.gitignore.content
     installer.package_json_str = installer.package_json.content
     installer.run_form_tests_str = installer.run_form_tests.content
-    
+  
   installer.update_github()
   update_github = True
 ---
@@ -202,7 +205,7 @@ fields:
     datatype: yesnoradio
   - Do you want to update or override those secrets?: wants_to_update_secrets
     datatype: yesnoradio
-    show if:
+    enable if:
       variable: already_has_secrets
       is: True
   # If is org admin
@@ -436,6 +439,8 @@ fields:
       
       Next, we need the URL of the GitHub repository. Example:[BR]
       **https://github.com/TheLawFantastic/docassemble-GreatForm**
+      
+      The package name in the repo url must be **exactly** as it appears in GitHub, including lowercase and uppercase letters.
     show if:
       code: |
         wants_to_set_up_tests or secret_type_wanted == 'repo'
@@ -470,8 +475,9 @@ content: |
   % endif
 ---
 template: files_list
+# TODO
 content: |
-  * **tests/features/example_test.feature** is a very simple example of a test.
+  * **tests/features/.feature** is a very simple example of a test.
   * **.github/workflows/run_interview_tests.yml** tells GitHub when and how to run the tests and save the files created.
   * **package.json** lets GitHub load other packages it needs to run the tests.
   * **.gitignore** is for developers who want to work in their local environment.
@@ -483,7 +489,20 @@ content: |
   * ${ secret_name }
   % endfor
 ---
-id: confirm info
+id: first test
+question: |
+  The first test
+subquestion: |
+  We can create your first tests for you if you want. The tests will go to the first page of each interview and check that it loads. You can always edit or delete them in your "Sources" folder later.
+  
+  If you want to make one later instead, save this link to [our documentation](https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/automated_integrated_testing).
+fields:
+  - Which interview files to you want the test to use?: installer.test_files_wanted
+    datatype: checkboxes
+    code: |
+      installer.get_question_file_names()
+---
+id: confirm info review
 question: |
   Is this information correct?
 subquestion: |
@@ -537,6 +556,15 @@ review:
       * **Package name**:[BR]
       ${ installer.package_name }
       
+      * **Test files**:[BR]\
+      % if installer.test_files_wanted.any_true():
+      % for test_file in installer.test_files_wanted.true_values():
+      ${ test_file }[BR]
+      % endfor
+      % else:
+      None
+      % endif
+      
       The new branch will be named **${ installer.branch_name }**.
       % endif
       
@@ -554,21 +582,17 @@ question: |
   Your GitHub settings should be updated!
 subquestion: |
   **Finish setting up**
-  
-  ---
-  
+    
   % if secret_type_wanted == 'org' or secret_type_wanted == 'repo':
-  ${ len( secrets_names ) } [GitHub secrets](https://docs.github.com/en/actions/reference/encrypted-secrets) were set to store {encrypted docassemble login information} safely:
+  ---
+
+  ${ len( secrets_names ) } [encrypted GitHub secrets](https://docs.github.com/en/actions/reference/encrypted-secrets) were created to store the testing account's login information:
   
   ${ secrets_list }
   % endif
   
-  % if secret_type_wanted == 'repo' or secret_type_wanted == 'org':
-  Secrets:
-  % endif
-  
   % if secret_type_wanted == 'repo':
-  [Make sure the repository secrets got created](https://github.com/${ installer.owner_name }/${ installer.repo_name }/settings/secrets/actions).
+  If you have enough permissions, [make sure the repository secrets got created](https://github.com/${ installer.owner_name }/${ installer.repo_name }/settings/secrets/actions).
   % endif
   
   % if secret_type_wanted == 'org':
@@ -577,42 +601,40 @@ subquestion: |
   % endif
   
   % if secret_type_wanted == 'org':
-  Team members that are collaborators can now use this interview to set up tests for their repositories. When they ask you if organization secrets or repo secrets have been set up, you can answer 'yes'.
+  Team members that are collaborators can now use this interview to set up tests for their repositories. When they ask you if organization secrets or repo secrets have been set up, you can answer "yes".
   % endif
   
-  % if wants_to_set_up_tests:
+  % if not wants_to_set_up_tests:
+  [Follow this link to delete the personal access token](https://github.com/settings/tokens) you created.
+  
+  ---
+  % else:
+  ---
+  
   This tool should have created a new branch in the GitHub repository named **${ installer.branch_name }**. On that branch, these new folders and files should have been added:
   
   ${ files_list }
   
-  ---
+  This tool should also have made a new pull request for you with those files. To finish, follow these instructions regarding that pull request.
   
-  This tool should also have made a new pull request for you. To finish, follow these instructions regarding that pull request.
-  
-  1. [Follw this link to the pull request](${ installer.pull_url }) to make sure it got created.
-  1. [Follow this link to your actions page](https://github.com/${ installer.owner_name }/${ installer.repo_name }/actions) to see the first test being run on the new branch. It may take up to a few minutes to show up, but if all the information was correct it should pass and get a green checkmark.
+  1. [Follow this link to the pull request](${ installer.pull_url }) to make sure it got created.
+  1. [Follow this link to your actions page](https://github.com/${ installer.owner_name }/${ installer.repo_name }/actions) to see the first test being run on the new branch. It may take a few minutes to show up, but if all the information was correct it should pass and get a green checkmark.
   1. If the test fails with a red "x": [Follow these instructions to rerun the test](https://docs.github.com/en/actions/managing-workflow-runs/re-running-a-workflow) (a.k.a. the job). If it fails again, contact us.
-  1. If the test passes with a green checkmark: If you have a partner working on this with you, [follow the instructions at this link to request a review of that pull request](https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from the partner. You can also see [our documents about requesting a review](https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/github#request-others-test-your-code). If you are not working with a partner, you can just [follow these instructions to merge the pull request](https://docs.github.com/en/github/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/merging-a-pull-request).
-  1. [Follow this link to the personal access token](https://github.com/settings/tokens) you created and delete it.
+  1. If the test passes with a green checkmark, get a partner to [review it](https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) or [follow these instructions to merge the pull request](https://docs.github.com/en/github/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/merging-a-pull-request).
+  1. [Follow this link to delete the personal access token](https://github.com/settings/tokens) you created.
   
   ---
   % endif
   
-  % if not wants_to_set_up_tests:
-  [Follow this link to the personal access token](https://github.com/settings/tokens) you created and delete it.
-  
-  ---
-  % endif
-  
-  If you want to go for a wild ride, you can read some rough docs at [https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/automated_integrated_testing](https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/automated_integrated_testing/).
-  
-  ---
+  If you want to disable the tests or just learn more, see [Assembly Line Kiln's documentation](https://suffolklitlab.github.io/docassemble-AssemblyLine-documentation/docs/automated_integrated_testing).
   
   If you have some feedback, we would love to hear from you! Let us know in chat or [make a public "issue" in our repository](https://github.com/plocket/docassemble-ALAutomatedTestingTests/issues/new).
+  
+  ---
 buttons:
   - Start again: restart
-terms:
-  encrypted docassemble login information: ${ secrets_popover }
+#terms:
+#  encrypted docassemble login information: ${ secrets_popover }
 comment: |
   TODO: Should we offer to delete their personal access token for them in the interview itself? Do we have enough permissions?
   TODO: Implement feedback form instead of linking issues. See AL core for that.

--- a/docassemble/ALAutomatedTestingTests/data/questions/al_set_up_testing.yml
+++ b/docassemble/ALAutomatedTestingTests/data/questions/al_set_up_testing.yml
@@ -477,7 +477,9 @@ content: |
 template: files_list
 # TODO
 content: |
-  * **tests/features/.feature** is a very simple example of a test.
+  % if installer.test_files_wanted.any_true():
+  * **tests/features/interviews_run.feature** is a very simple example of a test.
+  % endif
   * **.github/workflows/run_interview_tests.yml** tells GitHub when and how to run the tests and save the files created.
   * **package.json** lets GitHub load other packages it needs to run the tests.
   * **.gitignore** is for developers who want to work in their local environment.
@@ -570,9 +572,19 @@ review:
       
       ---
   - note: |
+      % if wants_to_set_up_tests:
+      If you continue, this setup will make a new branch and create or overwrite these files:
+      
+      ${ files_list }
+      
+      You can edit them before merging the branch.
+      
+      ---
+      % endif
+      
       There may be a few more steps after this to finish up. Continue when you are ready.
       
-      You will not be able to come back to this page.
+      **You will not be able to come back to this page.**
 continue button field: is_ready
 continue button label: Send to GitHub
 ---
@@ -611,7 +623,7 @@ subquestion: |
   % else:
   ---
   
-  This tool should have created a new branch in the GitHub repository named **${ installer.branch_name }**. On that branch, these new folders and files should have been added:
+  This tool should have created a new branch in the GitHub repository named **${ installer.branch_name }**. On that branch, these new folders and files should have been generated:
   
   ${ files_list }
   

--- a/docassemble/ALAutomatedTestingTests/data/questions/al_testing_files_to_push.yml
+++ b/docassemble/ALAutomatedTestingTests/data/questions/al_testing_files_to_push.yml
@@ -108,7 +108,7 @@ content: |
 # It just seemed more consistent
 template: installer.run_form_tests
 content: |
-  name: Test the interview
+  name: Run ALKiln automated tests
 
   on:
     push:

--- a/docassemble/ALAutomatedTestingTests/data/questions/al_testing_files_to_push.yml
+++ b/docassemble/ALAutomatedTestingTests/data/questions/al_testing_files_to_push.yml
@@ -5,6 +5,8 @@ comment: |
 ---
 template: installer.env_example
 content: |
+  # ALKiln .env file example
+
   # Username and password to log in to a docassemble playground to run tests
   PLAYGROUND_EMAIL=example@example.com
   PLAYGROUND_PASSWORD=12345
@@ -29,19 +31,31 @@ content: |
   # Change this to DEBUG=1 to run tests in a visible browser
   DEBUG=
 ---
-template: installer.example_test
+template: installer.first_feature_file
 content: |
-  @example_feature_tag
-  Feature: An example test
+  @interviews_start
+  Feature: The interviews run without erroring
 
   What specific behavior this file should test
-  [x] Make sure the Project runs on the server
-  [ ] Make sure the interview itself starts
-  [ ] Find the ultimate question to life, the universe, and everything.
+  [x] Each interview starts without an error
+  [x] Some example Steps are included that are commented out so they won't run
 
-  @example_scenario_tag
-  Scenario: Server finishes reloading
-    Given I start the interview at "test"
+  These tests are made to work with the ALKiln testing framework, an automated testing framework made under the Document Assembly Line Project.
+  
+  Want to disable the tests? See ALKiln's docs: https://suffolklitlab.github.io/docassemble-AssemblyLine-documentation/docs/automated_integrated_testing
+
+  % for file_name in installer.test_files_wanted.true_values():
+  @${ re.sub( r'[^A-Za-z09]+', '' , re.sub( r'\.yml', '', file_name )) }
+  Scenario: ${ file_name } runs
+    #Given I wait 20 seconds
+    Given I start the interview at "${ file_name }"
+    #And the maximum seconds for each Step in this scenario is 50
+    #And I get to the question id "downloads" with this data:
+    #  | var | value | trigger |
+    #  | users[0].name.first | Uli | users[0].name.first |
+    #  | users[0].name.last | User1 | users[0].name.first |
+    
+  % endfor
 ---
 template: installer.gitignore
 content: |
@@ -64,17 +78,12 @@ content: |
     "version": "0.1.0",
     "description": "",
     "main": "",
-    "directories": {
-      "test": "tests"
-    },
     "scripts": {
       "test": "npm run langs_setup && npm run cucumber -- $@",
       "cucumber_base": "./node_modules/.bin/cucumber-js --require ./node_modules/docassemble-cucumber/lib/index.js",
       "cucumber": "run_cucumber(){ npm run cucumber_base -- \"$@\" docassemble/*/data/sources/*.feature; }; run_cucumber",
       "langs": "npm run langs_setup && ./node_modules/.bin/cucumber-js --require ./node_modules/docassemble-cucumber/lib/index.js docassemble/*/data/sources/*_lang*.feature",
       "langs_setup": "node_modules/.bin/da-langs 'docassemble/*/data/sources/*.feature'",
-      "langs_local": "npm run langs_setup && npm run local",
-      "local": "npm run setup && npm run cucumber; npm run takedown",
       "setup": "node_modules/.bin/da-setup",
       "takedown": "node_modules/.bin/da-takedown"
     },
@@ -89,14 +98,9 @@ content: |
     },
     "homepage": "https://github.com/${ installer.owner_name }/${ installer.repo_name }#readme",
     "dependencies": {
-      "bufferutil": "^4.0.1",
-      "chai": "^4.2.0",
+      "colors": "1.4.0",
       "cucumber": "^6.0.5",
-      "docassemble-cucumber": "^3.0.0",
-      "dotenv": "^8.2.0",
-      "mocha": "^7.2.0",
-      "puppeteer": "^3.1.0",
-      "utf-8-validate": "^5.0.2"
+      "docassemble-cucumber": "^3.0.0"
     }
   }
 ---


### PR DESCRIPTION
and stop creating "example.feature" file on setup, removing the use of "test.yml" as the example.

Also:
- add info about disabling tests several places, providing a link to our documentation. The link just goes to the main automated testing page to be most robust in case of changes.
- add info about what files will be overwritten or created ahead of time (though maybe that info could be in a better place, though at earlier stages we don't know if a test file would be created).
- add the name ALKiln a bunch of places in the files that are pushed and the PR title and body.
- shortened some instructions
- updated package.json for 'colors' lib, etc.

Going to merge this one myself as well 🤞 

Close https://github.com/SuffolkLITLab/ALKiln/issues/485