### PR TITLE
32 obj dropdown

### DIFF
--- a/docassemble/ALAutomatedTestingTests/data/questions/all_tests.yml
+++ b/docassemble/ALAutomatedTestingTests/data/questions/all_tests.yml
@@ -174,24 +174,35 @@ objects:
   - obj_chkbx_opt_1: DAObject
   - obj_chkbx_opt_2: DAObject
   - obj_chkbx_opt_3: DAObject
+  - obj_opt_1: DAObject
+  - obj_opt_2: DAObject
+  - obj_opt_3: DAObject
 ---
 code: |
   obj_chkbx_opt_1.name = 'obj_chkbx_opt_1'
   obj_chkbx_opt_2.name = 'obj_chkbx_opt_2'
   obj_chkbx_opt_3.name = 'obj_chkbx_opt_3'
+  obj_opt_1.name = 'obj_opt_1'
+  obj_opt_2.name = 'obj_opt_2'
+  obj_opt_3.name = 'obj_opt_3'
 ---
 id: object checkboxes
 question: |
-  Object checkboxes
-subquestion: |
-  Made of list of objects. TODO: Add `object` choices dropdown.
+  Objects
 fields:
-  - no label: object_checkboxes_test
+  - Object checkboxes: object_checkboxes_test
     datatype: object_checkboxes
     choices:
       - obj_chkbx_opt_1
       - obj_chkbx_opt_2
       - obj_chkbx_opt_3
+  - Object dropdown: object_dropdown
+    required: False
+    datatype: object
+    choices:
+      - obj_opt_1
+      - obj_opt_2
+      - obj_opt_3
 ---
 id: buttons yesnomaybe
 question: |

--- a/docassemble/ALAutomatedTestingTests/data/questions/all_tests.yml
+++ b/docassemble/ALAutomatedTestingTests/data/questions/all_tests.yml
@@ -16,7 +16,7 @@ code: |
   double_quote_dict["double_quote_key"]
   direct_standard_fields
   direct_showifs
-  #object_checkboxes_test
+  object_checkboxes_test
   buttons_yesnomaybe
   buttons_other
   button_continue
@@ -197,7 +197,6 @@ fields:
       - obj_chkbx_opt_2
       - obj_chkbx_opt_3
   - Object dropdown: object_dropdown
-    required: False
     datatype: object
     choices:
       - obj_opt_1

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(name='docassemble.ALAutomatedTestingTests',
       url='https://docassemble.org',
       packages=find_packages(),
       namespace_packages=['docassemble'],
-      install_requires=['PyGithub>=1.55', 'PyNaCl>=1.4.0', 'requests>=2.25.1'],
+      install_requires=['PyGithub>=1.55', 'PyNaCl>=1.4.0', 'requests>=2.25.1', 'docassemble.ALToolbox'],
       zip_safe=False,
       package_data=find_package_data(where='docassemble/ALAutomatedTestingTests/', package='docassemble.ALAutomatedTestingTests'),
      )


### PR DESCRIPTION
Had started working on this independently, but realized that much of the work was already done in this branch so I rebased and finished it off.

Adds the `object_dropdown` variable, set by an object dropdown, and brings back the object checkbox / object dropdown screen. 