### PR TITLE
Increased the contrast of daterms to pass a11y

### DIFF
--- a/docassemble/ALAutomatedTestingTests/data/questions/all_tests.yml
+++ b/docassemble/ALAutomatedTestingTests/data/questions/all_tests.yml
@@ -3,6 +3,10 @@ metadata:
   short title: Test ALKiln
   comment: Test the automated integrated testing library for AssemblyLine
 ---
+features:
+  css:
+    - styles.css
+---
 # Necessary to tell us what the sought var is on each page
 # Every interview that wants testing will need to have an element like this
 default screen parts:

--- a/docassemble/ALAutomatedTestingTests/data/static/styles.css
+++ b/docassemble/ALAutomatedTestingTests/data/static/styles.css
@@ -35,6 +35,8 @@ ul {
 .daterm, .daterm:hover {
   text-decoration: underline dashed;
   text-underline-offset: 2px;
+  /* Increases the contrast so it doesn't fail. */
+  color: #3b842c;
 }
 
 .da-review ul {


### PR DESCRIPTION
Took the value from AssemblyLine's daterm color:
https://github.com/SuffolkLITLab/docassemble-AssemblyLine/commit/9da13d83a637b3747fca8da5a393255f1651468f#diff-bbf9d6a952063b08c912aaa7ba9c6089916929e83692f579f5dd3c614e653e7fR121

Needed to pass tests for https://github.com/SuffolkLITLab/ALKiln/pull/561. 