### PR TITLE
Add simple dropdown field that failed on latest

### DIFF
--- a/docassemble/ALAutomatedTestingTests/data/questions/all_tests.yml
+++ b/docassemble/ALAutomatedTestingTests/data/questions/all_tests.yml
@@ -31,7 +31,7 @@ code: |
   see_simple_doc
   
   button_event_action
-  simple_dropdown_field
+  single_dropdown_field
   end
 ---
 id: upload files
@@ -279,9 +279,9 @@ action buttons:
     action: end
     icon: laugh-wink
 ---
-id: Simple dropdown field
-question: Simple dropdown field
-field: simple_dropdown_field
+id: Single dropdown field
+question: Single dropdown field
+field: single_dropdown_field
 dropdown:
   - Efile and serve: efile_and_serve
   - Email: email

--- a/docassemble/ALAutomatedTestingTests/data/questions/all_tests.yml
+++ b/docassemble/ALAutomatedTestingTests/data/questions/all_tests.yml
@@ -31,6 +31,7 @@ code: |
   see_simple_doc
   
   button_event_action
+  simple_dropdown_field
   end
 ---
 id: upload files
@@ -277,6 +278,15 @@ action buttons:
   - label: Do not pass go
     action: end
     icon: laugh-wink
+---
+id: Simple dropdown field
+question: Simple dropdown field
+field: simple_dropdown_field
+dropdown:
+  - Efile and serve: efile_and_serve
+  - Email: email
+  - Mail: mail
+  - Hand delivery: hand_delivery
 ---
 id: simple doc
 question: |


### PR DESCRIPTION
When a single field page with the dropdown field is present, no fields on the page are detected. Originally found when I was testing the  by the [`method_of_service` var from the SP6A.yml interview](https://github.com/SuffolkLITLab/docassemble-MotionToStayEviction/blob/db2598102cc24b0bd4ec1048b1e5102c4b1d07b7/docassemble/MotionToStayEviction/data/questions/SP6A.yml#L357) in the [MotionToStayEviction](https://github.com/SuffolkLITLab/docassemble-MotionToStayEviction/) interview, This adds that test case to the `all_tests` interview. Not too intrusive, as only one feature file in ALKiln goes to the end of the `all_tests` interview.

Partners with https://github.com/SuffolkLITLab/ALKiln/pull/569, needs to be merged before that one.