### PR TITLE
Add test_gather for `there_is_another | False`

### DIFF
--- a/docassemble/ALAutomatedTestingTests/data/questions/test_gather.yml
+++ b/docassemble/ALAutomatedTestingTests/data/questions/test_gather.yml
@@ -1,0 +1,27 @@
+---
+objects:
+  - users: DAList.using(object_type=Individual)
+---
+mandatory: True
+code: |
+  set_up_users
+  users.gather()
+  end_screen
+---
+code: |
+  users.clear()
+  users.there_are_any = True
+  user0 = users.appendObject()
+  user0.name.first = 'Bob'
+  user0.name.last = 'Brown'
+  set_up_users = True
+---
+id: there_is_another
+question: Any more people?
+fields:
+  - no label: users.there_is_another
+    datatype: yesnoradio
+---
+id: end screen
+event: end_screen
+question: All done!


### PR DESCRIPTION
Sets up a valid situation where you would need `there_is_another` to be
directly set to false, instead of using `target_number` like the docs say.

First used in https://github.com/SuffolkLITLab/ALKiln/pull/580