### PR TITLE
Fix set org secret w/ no repo errors. 

### DIFF
--- a/docassemble/ALAutomatedTestingTests/data/questions/al_set_up_testing.yml
+++ b/docassemble/ALAutomatedTestingTests/data/questions/al_set_up_testing.yml
@@ -511,7 +511,7 @@ subquestion: |
   
   If you want to make one later instead, save this link to [our documentation](https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/automated_integrated_testing).
 fields:
-  - Which interview files to you want the test to use?: installer.test_files_wanted
+  - Which interview files do you want the test to use?: installer.test_files_wanted
     datatype: checkboxes
     code: |
       installer.get_question_file_names()
@@ -620,7 +620,7 @@ subquestion: |
   
   % if secret_type_wanted == 'org':
   1. [Make sure the organization secrets got created]( https://github.com/organizations/${ installer.org.login }/settings/secrets/actions).
-  1. Make sure the secrets have the [access settings](https://docs.github.com/en/actions/reference/encrypted-secrets#reviewing-access-to-organization-level-secrets) you need.
+  1. Make sure the secrets have the [access settings](https://docs.github.com/en/actions/reference/encrypted-secrets#reviewing-access-to-organization-level-secrets) you need. The defaults should be fine in most cases.
   % endif
   
   % if secret_type_wanted == 'org':

--- a/docassemble/ALAutomatedTestingTests/data/questions/al_set_up_testing.yml
+++ b/docassemble/ALAutomatedTestingTests/data/questions/al_set_up_testing.yml
@@ -46,7 +46,8 @@ code: |
   set_github_auth
   
   # Set them up with an example test file if they want
-  installer.test_files_wanted
+  if wants_to_set_up_tests:
+    installer.test_files_wanted
   
   # review/confirm
   is_ready
@@ -189,9 +190,9 @@ question: |
   What do you need to do?
 subquestion: |
   % if is_org_admin:
-  Using this form you can {set up GitHub secrets} or set up the testing package files in a repository or both. If you set up secrets, you can choose to create secrets for your organization or for a specific repository.
+  Using this form you can {set up GitHub secrets}, or set up the testing package files in a repository, or both. If you set up secrets, you can choose to create secrets for your organization or for a specific repository.
   % else:
-  Using this form you can set up GitHub secrets for the repository or set up the testing package files in the repository or both.
+  Since you are NOT an admin, you can only use this form to do the set up for an individual **repository**. You can use it to set up GitHub secrets for that repository, or set up the testing package files in the repository, or both.
   % endif
   
   ---
@@ -204,9 +205,19 @@ subquestion: |
   **Pause here.** Ask your admin whether your organization or repository already has the {right GitHub secrets}.
   % endif
 fields:
-  # Always
+  # If is org admin
   - Has someone already set up the repository or organization secrets?: already_has_secrets
+    show if:
+      code: |
+        is_org_admin
     datatype: yesnoradio
+  # If NOT org admin
+  - Has someone already set up the repository's secrets?: already_has_secrets
+    show if:
+      code: |
+        is_org_admin is False
+    datatype: yesnoradio
+  # Always
   - Do you want to update or override those secrets?: wants_to_update_secrets
     datatype: yesnoradio
     show if:
@@ -435,7 +446,7 @@ subquestion: |
   1. Finish creating the personal access token.
   1. Copy the token and paste it below.
 fields:
-  - Personal access token: installer.token
+  - GitHub personal access token: installer.token
     datatype: password
     help: |
       The token must have ${ token_permissions_scope } permissions.
@@ -463,7 +474,7 @@ fields:
     show if:
       code: |
         not wants_to_set_up_tests and secret_type_wanted == 'org'
-  - Organization name: installer.owner_name
+  - GitHub organization name: installer.owner_name
     show if:
       code: |
         not wants_to_set_up_tests and secret_type_wanted == 'org'

--- a/docassemble/ALAutomatedTestingTests/data/questions/al_set_up_testing.yml
+++ b/docassemble/ALAutomatedTestingTests/data/questions/al_set_up_testing.yml
@@ -619,8 +619,7 @@ subquestion: |
   % endif
   
   % if secret_type_wanted == 'org':
-  1. [Make sure the organization secrets got created]( https://github.com/organizations/${ installer.org.login }/settings/secrets/actions).
-  1. Make sure the secrets have the [access settings](https://docs.github.com/en/actions/reference/encrypted-secrets#reviewing-access-to-organization-level-secrets) you need. The defaults should be fine in most cases.
+  [Make sure the organization secrets got created]( https://github.com/organizations/${ installer.org.login }/settings/secrets/actions).
   % endif
   
   % if secret_type_wanted == 'org':

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ from distutils.util import convert_path
 
 standard_exclude = ('*.pyc', '*~', '.*', '*.bak', '*.swp*')
 standard_exclude_directories = ('.*', 'CVS', '_darcs', './build', './dist', 'EGG-INFO', '*.egg-info')
+
 def find_package_data(where='.', package='', exclude=standard_exclude, exclude_directories=standard_exclude_directories):
     out = {}
     stack = [(convert_path(where), '', package)]
@@ -53,7 +54,7 @@ setup(name='docassemble.ALAutomatedTestingTests',
       url='https://docassemble.org',
       packages=find_packages(),
       namespace_packages=['docassemble'],
-      install_requires=['PyGithub>=1.55', 'PyNaCl>=1.5.0', 'docassemble.ALToolbox>=0.5.1', 'requests>=2.27.1'],
+      install_requires=['PyGithub>=1.55', 'PyNaCl>=1.5.0', 'docassemble.ALToolbox>=0.6.2', 'requests>=2.27.1'],
       zip_safe=False,
       package_data=find_package_data(where='docassemble/ALAutomatedTestingTests/', package='docassemble.ALAutomatedTestingTests'),
      )


### PR DESCRIPTION
Fix error that happens when the user wants to set org secrets, but does not want to create tests for a repo and gets `installer.repo` doesn't exist.

Also tweaks some language to, I hope, add clarity.

Also, removes a part of the follow-up instructions that's actually too complex to handle in this set up interview:
> Remove instructions to check access settings for org secrets. This is actually a pretty advanced step. If the user opens up the org secret to change settings, I believe it will erase the secret and they won't know what to put in there. We should add this as a documentation issue so that we put this in the documentation instead (with more details).