### PR TITLE
Use actions/checkout@v3

### DIFF
--- a/docassemble/ALAutomatedTestingTests/data/questions/al_testing_files_to_push.yml
+++ b/docassemble/ALAutomatedTestingTests/data/questions/al_testing_files_to_push.yml
@@ -55,7 +55,7 @@ content: |
       runs-on: ubuntu-latest
       name: Run interview tests
       steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
         - name: Use ALKiln to run tests
           uses: SuffolkLITLab/ALKiln@releases/v4
           with:


### PR DESCRIPTION
v2 is on node 12, which is deprecated for GitHub actions and will be removed soon.